### PR TITLE
Make Docker builds faster by skipping tests when building a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN ./gradlew --no-daemon assemble || return 0
 
 ## Build the app
 COPY . .
-RUN ./gradlew --no-daemon build installDist
+RUN ./gradlew --no-daemon installDist
 
 
 # Stage 2: distribution container

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,7 @@
+version: "3.4"
+services:
+  sut:
+    build:
+      context: .
+      target: builder
+    command: ./gradlew --no-daemon check


### PR DESCRIPTION
We were running all the tests with every Docker build so that DockerHub automatic builds would not accidentally succeed and push a broken image. Tests are now run using DockerHub's [automatic testing infrastructure](https://docs.docker.com/docker-hub/builds/automated-testing/), so we get the same reliability without making *every* build slow.