### PR TITLE
Changed interface for selectors for solver interface

### DIFF
--- a/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/ABYSelector.kt
+++ b/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/ABYSelector.kt
@@ -8,7 +8,6 @@ import edu.cornell.cs.apl.viaduct.syntax.Host
 import edu.cornell.cs.apl.viaduct.syntax.HostTrustConfiguration
 import edu.cornell.cs.apl.viaduct.syntax.Protocol
 import edu.cornell.cs.apl.viaduct.syntax.SpecializedProtocol
-import edu.cornell.cs.apl.viaduct.syntax.Variable
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.DeclarationNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.LetNode
 import edu.cornell.cs.apl.viaduct.util.subsequences
@@ -54,7 +53,7 @@ class ABYSelector(
         }
     }
 
-    override fun select(node: LetNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> {
+    override fun viableProtocols(node: LetNode): Set<Protocol> {
         if (node.isApplicable()) {
             return protocols.filter { it.authority.actsFor(informationFlowAnalysis.label(node)) }.map { it.protocol }
                 .toSet()
@@ -63,7 +62,7 @@ class ABYSelector(
         }
     }
 
-    override fun select(node: DeclarationNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> {
+    override fun viableProtocols(node: DeclarationNode): Set<Protocol> {
         if (node.isApplicable()) {
             return protocols.filter { it.authority.actsFor(informationFlowAnalysis.label(node)) }.map { it.protocol }
                 .toSet()

--- a/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/LocalSelector.kt
+++ b/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/LocalSelector.kt
@@ -6,7 +6,6 @@ import edu.cornell.cs.apl.viaduct.syntax.Host
 import edu.cornell.cs.apl.viaduct.syntax.HostTrustConfiguration
 import edu.cornell.cs.apl.viaduct.syntax.Protocol
 import edu.cornell.cs.apl.viaduct.syntax.SpecializedProtocol
-import edu.cornell.cs.apl.viaduct.syntax.Variable
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.DeclarationNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.LetNode
 
@@ -18,13 +17,13 @@ class LocalSelector(
     private val protocols: List<SpecializedProtocol> =
         hosts.map(::Local).map { SpecializedProtocol(it, hostTrustConfiguration) }
 
-    override fun select(node: LetNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> {
+    override fun viableProtocols(node: LetNode): Set<Protocol> {
         return protocols.filter { it.authority.actsFor(informationFlowAnalysis.label(node)) }.map { it.protocol }
             .toSet()
     }
 
-    override fun select(node: DeclarationNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> {
+    override fun viableProtocols(node: DeclarationNode): Set<Protocol> {
         return protocols.filter { it.authority.actsFor(informationFlowAnalysis.label(node)) }.map { it.protocol }
-            .toSet()
+        .toSet()
     }
 }

--- a/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/ProtocolSelector.kt
+++ b/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/ProtocolSelector.kt
@@ -1,31 +1,46 @@
 package edu.cornell.cs.apl.viaduct.selection
 
 import edu.cornell.cs.apl.viaduct.syntax.Protocol
-import edu.cornell.cs.apl.viaduct.syntax.Variable
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.DeclarationNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.LetNode
 
 /**
-This interface specifies selectors for protocol selection. Selectors are given a partial assignment
-of protocols selected so far, and either a LetNode or DeclarationNode,
-and outputs a set of protocols which can implement that node.
+This interface specifies selectors for protocol selection.
+The role of a selector is twofold:
+    - first, it outputs the set of viable protocols which may be selected at that node.
+          A protocol is viable for a node if it satisfies both the information flow constraints
+          and syntactic restrictions for that node.
+    - Second, it outputs a constraints for that node. The constraints encode all of the other interdependencies present
+      in protocol selection.
 
 Protocol selectors do NOT have to enforce that the selected protocols have enough authority to implement the node.
-This invariant is enforced during protocol selection.
+This invariant is enforced during protocol selection. However for efficiency it is better for them so.
 
  **/
 
 interface ProtocolSelector {
-    fun select(node: LetNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol>
-    fun select(node: DeclarationNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol>
+    fun viableProtocols(node: LetNode): Set<Protocol>
+    fun viableProtocols(node: DeclarationNode): Set<Protocol>
+    fun constraint(node: LetNode): SelectionConstraint {
+        return Literal(true)
+    }
+    fun constraint(node: DeclarationNode): SelectionConstraint {
+        return Literal(true)
+    }
 }
 
 /* Union of protocol selectors. [unions] takes a number of selectors and implements their collective union. */
 
 fun unions(vararg selectors: ProtocolSelector): ProtocolSelector = object : ProtocolSelector {
-    override fun select(node: LetNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> =
-        selectors.fold(setOf()) { acc, sel -> acc.union(sel.select(node, currentAssignment)) }
+    override fun viableProtocols(node: LetNode): Set<Protocol> =
+        selectors.fold(setOf()) { acc, sel -> acc.union(sel.viableProtocols(node)) }
 
-    override fun select(node: DeclarationNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> =
-        selectors.fold(setOf()) { acc, sel -> acc.union(sel.select(node, currentAssignment)) }
+    override fun viableProtocols(node: DeclarationNode): Set<Protocol> =
+        selectors.fold(setOf()) { acc, sel -> acc.union(sel.viableProtocols(node)) }
+
+    override fun constraint(node: LetNode): SelectionConstraint =
+        selectors.fold<ProtocolSelector, SelectionConstraint>(Literal(true)) { acc, sel -> And(acc, sel.constraint(node)) }
+
+    override fun constraint(node: DeclarationNode): SelectionConstraint =
+        selectors.fold<ProtocolSelector, SelectionConstraint>(Literal(true)) { acc, sel -> And(acc, sel.constraint(node)) }
 }

--- a/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/ReplicationSelector.kt
+++ b/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/ReplicationSelector.kt
@@ -6,7 +6,6 @@ import edu.cornell.cs.apl.viaduct.syntax.Host
 import edu.cornell.cs.apl.viaduct.syntax.HostTrustConfiguration
 import edu.cornell.cs.apl.viaduct.syntax.Protocol
 import edu.cornell.cs.apl.viaduct.syntax.SpecializedProtocol
-import edu.cornell.cs.apl.viaduct.syntax.Variable
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.DeclarationNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.LetNode
 import edu.cornell.cs.apl.viaduct.util.subsequences
@@ -20,12 +19,12 @@ class ReplicationSelector(
     private val protocols: List<SpecializedProtocol> =
         hostSubsets.map(::Replication).map { SpecializedProtocol(it, hostTrustConfiguration) }
 
-    override fun select(node: LetNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> {
+    override fun viableProtocols(node: LetNode): Set<Protocol> {
         return protocols.filter { it.authority.actsFor(informationFlowAnalysis.label(node)) }.map { it.protocol }
             .toSet()
     }
 
-    override fun select(node: DeclarationNode, currentAssignment: Map<Variable, Protocol>): Set<Protocol> {
+    override fun viableProtocols(node: DeclarationNode): Set<Protocol> {
         return protocols.filter { it.authority.actsFor(informationFlowAnalysis.label(node)) }.map { it.protocol }
             .toSet()
     }

--- a/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/SelectionConstraint.kt
+++ b/src/main/kotlin/edu/cornell/cs/apl/viaduct/selection/SelectionConstraint.kt
@@ -1,0 +1,26 @@
+package edu.cornell.cs.apl.viaduct.selection
+
+import edu.cornell.cs.apl.viaduct.syntax.Protocol
+import edu.cornell.cs.apl.viaduct.syntax.Variable
+
+sealed class SelectionConstraint
+
+data class Literal(val literalValue: Boolean) : SelectionConstraint()
+data class Implies(val lhs: SelectionConstraint, val rhs: SelectionConstraint) : SelectionConstraint()
+data class Or(val lhs: SelectionConstraint, val rhs: SelectionConstraint) : SelectionConstraint()
+data class VariableIn(val variable: Variable, val protocols: Set<Protocol>) : SelectionConstraint()
+data class Not(val rhs: SelectionConstraint) : SelectionConstraint()
+data class And(val lhs: SelectionConstraint, val rhs: SelectionConstraint) : SelectionConstraint()
+
+fun Boolean.implies(r: Boolean) = (!this) || r
+
+fun SelectionConstraint.evaluate(f: (Variable) -> Protocol): Boolean {
+    return when (this) {
+        is Literal -> literalValue
+        is Implies -> lhs.evaluate(f).implies(rhs.evaluate(f))
+        is Or -> (lhs.evaluate(f)) || (rhs.evaluate(f))
+        is And -> (lhs.evaluate(f)) && (rhs.evaluate(f))
+        is VariableIn -> protocols.contains(f(variable))
+        is Not -> !(rhs.evaluate(f))
+    }
+}


### PR DESCRIPTION
This change changes the protocol selectors to support two functions:

- The first, `viableProtocols`, returns the total set of protocols that could possibly be considered for that node, for some protocol selection. The protocols output from this function are those which are candidates for selection.

- The second, `constraint`, returns the set of constraints that involve the node in question. These constraints do not model the viability of any protocol for that node alone, but instead will model the interdependencies between protocol selections. 

For example, suppose we have a statement, `let t = t1 + t2`, and later on, we have `let t3 = t1 + t4`. Suppose `t` is selected for protocol `P`. There are two kinds of constraints we can put on `t`:
1. Constraints on the readers of `t`; i.e., `t3` in our example. If `P` can send to protocols `P`, `Q` and `R`, we would add as a constraint that `t3` must be either `Q` or `R`.
2. Constraints on the things `t` reads from; i.e., `t1` and t2` in our example. If `P` can only read from `P` and `Q`, we would correspondingly add this as a constraint.

I have also fixed `SimpleSelection` to maintain the constraints accumulated during selection, and check at the end whether the (naive) search respects the constraints. Currently no protocols output nontrivial constraints, so this assertion always succeeds.

