### PR TITLE
Apply Spotless to more files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ library for showing additional information to the user.
 Logs go to standard error in accordance with Unix conventions, and the user can
 control the granularity of logs using the `--verbose` flag.
 
-As a general rule, *never* use `print()` or `println()` to display information
+As a general rule, _never_ use `print()` or `println()` to display information
 to the user. This includes showing information to yourself for debugging.
 All logging frameworks have a `DEGUB` level, and if you found this information
 useful, chances are it will be relevant later.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,26 +27,25 @@ allprojects {
     /** Style */
 
     spotless {
+        java {
+            target("src/**/*.java")
+            googleJavaFormat()
+        }
         kotlinGradle {
             ktlint()
+        }
+    }
+
+    pluginManager.withPlugin("kotlin") {
+        spotless {
+            kotlin {
+                ktlint()
+            }
         }
     }
 }
 
 /** Style */
-
-project(":compiler") {
-    spotless {
-        // TODO: remove once Java is gone
-        java {
-            target("src/**/*.java")
-            googleJavaFormat()
-        }
-        kotlin {
-            ktlint()
-        }
-    }
-}
 
 spotless {
     format("markdown") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,19 @@ project(":compiler") {
     }
 }
 
+spotless {
+    format("markdown") {
+        target("**/*.md")
+        targetExclude("**/build/**")
+        prettier()
+    }
+    format("YAML") {
+        target("**/*.yml", "**/*.yaml")
+        targetExclude("**/build/**")
+        prettier()
+    }
+}
+
 editorconfig {
     excludes = listOf("$buildDir", "**/out", "gradlew", ".kotlin", "**/*.hprof")
 }


### PR DESCRIPTION
I tried to apply the Spotless plugin to YAML and Markdown files. Unfortunately, this requires the system to have NPM installed (Gradle won't install it for you). The beautiful thing about our build is it only requires Java. I don't want to change that.