### PR TITLE
Add a copy method to Node and make copies when generating code

### DIFF
--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/attributes/Trees.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/attributes/Trees.kt
@@ -66,6 +66,7 @@ class Tree<Node : TreeNode<Node>, out RootNode : Node>(val root: RootNode) {
 /** A node in a [Tree]. */
 interface TreeNode<out Node> {
     /** The list of all children nodes. This is empty for leaf nodes. */
+    // TODO: this should be a list
     val children: Iterable<Node>
 }
 

--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/passes/Splitting.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/passes/Splitting.kt
@@ -10,11 +10,13 @@ import edu.cornell.cs.apl.viaduct.syntax.Protocol
 import edu.cornell.cs.apl.viaduct.syntax.ProtocolNode
 import edu.cornell.cs.apl.viaduct.syntax.ValueTypeNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.AssertionNode
+import edu.cornell.cs.apl.viaduct.syntax.intermediate.AtomicExpressionNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.BlockNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.BreakNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.IfNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.InfiniteLoopNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.LetNode
+import edu.cornell.cs.apl.viaduct.syntax.intermediate.Node
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.ProcessDeclarationNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.ProgramNode
 import edu.cornell.cs.apl.viaduct.syntax.intermediate.ReadNode
@@ -82,7 +84,7 @@ fun ProcessDeclarationNode.split(
                 is IfNode ->
                     listOf(
                         IfNode(
-                            it.guard,
+                            it.guard.deepCopy() as AtomicExpressionNode,
                             it.thenBranch.projectFor(protocol),
                             it.elseBranch.projectFor(protocol),
                             it.sourceLocation
@@ -99,10 +101,10 @@ fun ProcessDeclarationNode.split(
                     )
 
                 is BreakNode ->
-                    listOf(it)
+                    listOf(it.deepCopy() as StatementNode)
 
                 is AssertionNode ->
-                    listOf(it)
+                    listOf(it.deepCopy() as StatementNode)
 
                 is BlockNode ->
                     listOf(it.projectFor(protocol))
@@ -143,3 +145,7 @@ fun ProgramNode.splitMain(protocolAnalysis: ProtocolAnalysis): ProgramNode {
     }
     return ProgramNode(declarations, this.sourceLocation)
 }
+
+/** Like [Node.copy], but recursively copies all descendant nodes also.*/
+private fun Node.deepCopy(): Node =
+    this.copy(this.children.toList().map { it.deepCopy() })

--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/Node.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/Node.kt
@@ -1,5 +1,6 @@
 package edu.cornell.cs.apl.viaduct.syntax.intermediate
 
+import edu.cornell.cs.apl.attributes.Tree
 import edu.cornell.cs.apl.attributes.TreeNode
 import edu.cornell.cs.apl.prettyprinting.Document
 import edu.cornell.cs.apl.prettyprinting.PrettyPrintable
@@ -25,6 +26,18 @@ abstract class Node : TreeNode<Node>, HasSourceLocation, PrettyPrintable {
      * This is useful, for example, for [pretty printing][PrettyPrintable].
      */
     abstract fun toSurfaceNode(): edu.cornell.cs.apl.viaduct.syntax.surface.Node
+
+    /**
+     * Returns a shallow copy of this node where the child nodes are replaced by [children].
+     *
+     * This method can be used to generate objects with unique object identities, for example,
+     * when constructing a [Tree] since [Tree] assumes there is no sharing.
+     *
+     * The returned node is guaranteed to have a new object identity even if [children] exactly matches the
+     * children of this node, however, the nodes in [children] themselves are not copied.
+     * This method assumes that [children] contains the correct number and types of nodes.
+     */
+    abstract fun copy(children: List<Node> = this.children.toList()): Node
 
     final override val asDocument: Document
         get() = toSurfaceNode().asDocument

--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/ProgramNode.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/ProgramNode.kt
@@ -27,6 +27,9 @@ private constructor(
             sourceLocation
         )
 
+    override fun copy(children: List<Node>): ProgramNode =
+        ProgramNode(children.map { it as TopLevelDeclarationNode }, sourceLocation)
+
     override fun toString(): String =
         "Program (" + sourceLocation.sourcePath + ")"
 }

--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/Statements.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/Statements.kt
@@ -19,6 +19,8 @@ import kotlinx.collections.immutable.toPersistentList
 /** A computation with side effects. */
 sealed class StatementNode : Node() {
     abstract override fun toSurfaceNode(): edu.cornell.cs.apl.viaduct.syntax.surface.StatementNode
+
+    abstract override fun copy(children: List<Node>): StatementNode
 }
 
 /**
@@ -29,6 +31,8 @@ sealed class SimpleStatementNode : StatementNode() {
     abstract override val children: Iterable<ExpressionNode>
 
     abstract override fun toSurfaceNode(): edu.cornell.cs.apl.viaduct.syntax.surface.SimpleStatementNode
+
+    abstract override fun copy(children: List<Node>): SimpleStatementNode
 }
 
 // Simple Statements
@@ -48,6 +52,9 @@ class LetNode(
             value.toSurfaceNode(),
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): LetNode =
+        LetNode(temporary, children[0] as ExpressionNode, sourceLocation)
 }
 
 /** Constructing a new object and binding it to a variable. */
@@ -72,6 +79,16 @@ class DeclarationNode(
             Arguments(arguments.map { it.toSurfaceNode() }, arguments.sourceLocation),
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): DeclarationNode =
+        DeclarationNode(
+            variable,
+            className,
+            typeArguments,
+            labelArguments,
+            Arguments(children.map { it as AtomicExpressionNode }, arguments.sourceLocation),
+            sourceLocation
+        )
 }
 
 /** An update method applied to an object. */
@@ -89,6 +106,14 @@ class UpdateNode(
             variable,
             update,
             Arguments(arguments.map { it.toSurfaceNode() }, arguments.sourceLocation),
+            sourceLocation
+        )
+
+    override fun copy(children: List<Node>): UpdateNode =
+        UpdateNode(
+            variable,
+            update,
+            Arguments(children.map { it as AtomicExpressionNode }, arguments.sourceLocation),
             sourceLocation
         )
 }
@@ -110,6 +135,9 @@ class OutputNode(
             host,
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): OutputNode =
+        OutputNode(children[0] as AtomicExpressionNode, host, sourceLocation)
 }
 
 /** Sending a value to another protocol. */
@@ -127,12 +155,17 @@ class SendNode(
             protocol,
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): SendNode =
+        SendNode(children[0] as AtomicExpressionNode, protocol, sourceLocation)
 }
 
 // Compound Statements
 
 /** A statement that affects control flow. */
-sealed class ControlNode : StatementNode()
+sealed class ControlNode : StatementNode() {
+    abstract override fun copy(children: List<Node>): ControlNode
+}
 
 /**
  * Executing statements conditionally.
@@ -156,6 +189,9 @@ class IfNode(
             elseBranch.toSurfaceNode(),
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): IfNode =
+        IfNode(children[0] as AtomicExpressionNode, children[1] as BlockNode, children[2] as BlockNode, sourceLocation)
 }
 
 /**
@@ -177,6 +213,9 @@ class InfiniteLoopNode(
             jumpLabel,
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): InfiniteLoopNode =
+        InfiniteLoopNode(children[0] as BlockNode, jumpLabel, sourceLocation)
 }
 
 /**
@@ -196,6 +235,9 @@ class BreakNode(
             jumpLabel,
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): BreakNode =
+        BreakNode(jumpLabel, sourceLocation)
 }
 
 /** Asserting that a condition is true, and failing otherwise. */
@@ -211,6 +253,9 @@ class AssertionNode(
             condition.toSurfaceNode(),
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): AssertionNode =
+        AssertionNode(children[0] as AtomicExpressionNode, sourceLocation)
 }
 
 /** A sequence of statements. */
@@ -233,4 +278,7 @@ private constructor(
             statements.map { it.toSurfaceNode() },
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): BlockNode =
+        BlockNode(children.map { it as StatementNode }, sourceLocation)
 }

--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/TopLevelDeclarations.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/TopLevelDeclarations.kt
@@ -30,6 +30,9 @@ class HostDeclarationNode(
             authority,
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): HostDeclarationNode =
+        HostDeclarationNode(name, authority, sourceLocation)
 }
 
 /**
@@ -52,4 +55,7 @@ class ProcessDeclarationNode(
             body.toSurfaceNode(),
             sourceLocation
         )
+
+    override fun copy(children: List<Node>): ProcessDeclarationNode =
+        ProcessDeclarationNode(protocol, children[0] as BlockNode, sourceLocation)
 }

--- a/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/NodeTest.kt
+++ b/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/syntax/intermediate/NodeTest.kt
@@ -1,0 +1,59 @@
+package edu.cornell.cs.apl.viaduct.syntax.intermediate
+
+import edu.cornell.cs.apl.viaduct.ExampleProgramProvider
+import edu.cornell.cs.apl.viaduct.passes.elaborated
+import edu.cornell.cs.apl.viaduct.syntax.surface.ProgramNode
+import edu.cornell.cs.apl.viaduct.syntax.surface.assertStructurallyEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+internal class NodeTest {
+    @ParameterizedTest
+    @ArgumentsSource(ExampleProgramProvider::class)
+    fun `copy returns structurally equivalent nodes`(surfaceProgram: ProgramNode) {
+        val program = surfaceProgram.elaborated()
+        assertStructurallyEquals(program.toSurfaceNode(), program.deepCopy().toSurfaceNode())
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ExampleProgramProvider::class)
+    fun `copy uses all children nodes`(surfaceProgram: ProgramNode) {
+        val program = surfaceProgram.elaborated()
+        program.trackingDeepCopy()
+    }
+}
+
+private fun Node.deepCopy(): Node =
+    this.copy(this.children.toList().map { it.deepCopy() })
+
+private fun Node.trackingDeepCopy(): Node {
+    val copiedChildren = TrackingList(this.children.toList().map { it.trackingDeepCopy() })
+    val copied = this.copy(copiedChildren)
+    assertEquals(0.until(copiedChildren.size).toSet(), copiedChildren.accessedIndices)
+    return copied
+}
+
+/** A list that tracks which indices have been accesses. */
+private class TrackingList<out A>(private val list: List<A>) : List<A> by list {
+    val accessedIndices = mutableSetOf<Int>()
+
+    override fun get(index: Int): A {
+        accessedIndices.add(index)
+        return list[index]
+    }
+
+    override fun iterator(): Iterator<A> = TrackingIterator()
+
+    inner class TrackingIterator : Iterator<A> {
+        private var index = 0
+
+        override fun hasNext(): Boolean = index < list.size
+
+        override fun next(): A {
+            val result = this@TrackingList[index]
+            index += 1
+            return result
+        }
+    }
+}

--- a/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/syntax/surface/StructuralEquality.kt
+++ b/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/syntax/surface/StructuralEquality.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.assertThrows
 import org.opentest4j.AssertionFailedError
 
 /** Asserts that [actual] equals [expected], but ignores [SourceLocation]s. */
+// TODO: extend this to also work with intermediate Nodes.
 internal fun assertStructurallyEquals(expected: Node, actual: Node) {
     // Actual must be from a compatible class
     if (!expected::class.isInstance(actual))


### PR DESCRIPTION
The attribute grammar infrastructure assumes that AST nodes are not shared since it needs to compute unique parent pointers. The splitter was sharing some nodes which caused Analyses to fail. We now copy nodes to create unique object identities, which fixes the problem.