### PR TITLE
Actually fix FreshNameGenerator

### DIFF
--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/util/FreshNameGenerator.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/util/FreshNameGenerator.kt
@@ -1,38 +1,32 @@
 package edu.cornell.cs.apl.viaduct.util
 
-import java.lang.Integer.max
-
 /** Generates distinct names. Never generates the same name twice. */
-class FreshNameGenerator(
-    names: Set<String> // the initial set of names that will populate the name map
-) {
-    private val freshNameMap: MutableMap<String, Int> = mutableMapOf()
+class FreshNameGenerator {
+    /**
+     * The keys are all the names returned by [getFreshName].
+     * The value mapped to a name is the first suffix that should be tried to distinguish that name.
+     */
+    private val returnedNames: MutableMap<String, Int> = mutableMapOf()
 
-    init {
-        for (name: String in names) {
-            getFreshName(name)
-        }
+    /**
+     * Returns a new name derived from [base]. The return name will be different from all previously returned names.
+     *
+     * If this is the first time [base] is passed to this function, then returns [base].
+     */
+    fun getFreshName(base: String): String {
+        var suffix = returnedNames[base] ?: 0
+        var proposedName: String
+
+        do {
+            proposedName = makeName(base, suffix)
+            suffix += 1
+        } while (returnedNames.containsKey(proposedName))
+
+        returnedNames[base] = suffix
+        returnedNames[proposedName] = 1
+        return proposedName
     }
 
-    constructor() : this(setOf())
-
-    /** Returns a new name derived from base. */
-    fun getFreshName(input: String): String {
-        val regex = Regex("_([0-9]+)\\z")
-        val match: MatchResult? = regex.find(input)
-
-        val base: String
-        val n: Int
-        if (match == null) {
-            base = input
-            n = freshNameMap[base] ?: 0
-        } else { // strip suffix "_[num]" from base to avoid collisions
-            val parsedNum: Int = match.groupValues[1].toInt()
-            base = input.substring(0, match.range.first)
-            n = max(freshNameMap[base] ?: 0, parsedNum)
-        }
-
-        freshNameMap[base] = n + 1
-        return if (n > 0) "${base}_$n" else base
-    }
+    private fun makeName(base: String, suffix: Int): String =
+        if (suffix == 0) base else "${base}_$suffix"
 }

--- a/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/util/FreshNameGeneratorTest.kt
+++ b/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/util/FreshNameGeneratorTest.kt
@@ -1,25 +1,60 @@
 package edu.cornell.cs.apl.viaduct.util
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 
-class FreshNameGeneratorTest {
+internal class FreshNameGeneratorTest {
     @Test
-    fun suffixStripTest() {
-        val nameGenerator = FreshNameGenerator()
-        nameGenerator.getFreshName("tmp")
-        val name2: String = nameGenerator.getFreshName("tmp_1")
-        val name3: String = nameGenerator.getFreshName("tmp")
-
-        assert(name2 != name3)
+    fun `already fresh names are unchanged`() {
+        val freshNameGenerator = FreshNameGenerator()
+        val x = freshNameGenerator.getFreshName("x")
+        val y = freshNameGenerator.getFreshName("y")
+        assertEquals("x", x)
+        assertEquals("y", y)
     }
 
     @Test
-    fun suffixStripTest2() {
-        val nameGenerator = FreshNameGenerator()
-        nameGenerator.getFreshName("tmp")
-        val name2: String = nameGenerator.getFreshName("tmp_01")
-        val name3: String = nameGenerator.getFreshName("tmp")
+    fun `already fresh names with suffixes are unchanged`() {
+        val freshNameGenerator = FreshNameGenerator()
+        val x = freshNameGenerator.getFreshName("x_0")
+        val y = freshNameGenerator.getFreshName("y_1")
+        assertEquals("x_0", x)
+        assertEquals("y_1", y)
+    }
 
-        assert(name2 != name3)
+    @Test
+    fun `generated names do not collide`() {
+        val freshNameGenerator = FreshNameGenerator()
+        val name1 = freshNameGenerator.getFreshName("tmp")
+        val name2 = freshNameGenerator.getFreshName("tmp")
+        assertNotEquals(name1, name2)
+    }
+
+    @Test
+    fun `generated names with suffixes do not collide`() {
+        val freshNameGenerator = FreshNameGenerator()
+        freshNameGenerator.getFreshName("tmp")
+        val name2: String = freshNameGenerator.getFreshName("tmp_1")
+        val name3: String = freshNameGenerator.getFreshName("tmp")
+        assertNotEquals(name2, name3)
+    }
+
+    @Test
+    fun `generated names with suffixes do not collide 2`() {
+        val freshNameGenerator = FreshNameGenerator()
+        freshNameGenerator.getFreshName("tmp")
+        val name2: String = freshNameGenerator.getFreshName("tmp_01")
+        val name3: String = freshNameGenerator.getFreshName("tmp")
+        assertNotEquals(name2, name3)
+    }
+
+    @Test
+    fun `generated names with nested suffixes do not collide`() {
+        val freshNameGenerator = FreshNameGenerator()
+        freshNameGenerator.getFreshName("tmp")
+        val name2: String = freshNameGenerator.getFreshName("tmp_1_0")
+        val name3: String = freshNameGenerator.getFreshName("tmp")
+        assertNotEquals(name2, name3)
     }
 }

--- a/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/util/FreshNameGeneratorTest.kt
+++ b/compiler/src/test/kotlin/edu/cornell/cs/apl/viaduct/util/FreshNameGeneratorTest.kt
@@ -17,10 +17,14 @@ internal class FreshNameGeneratorTest {
     @Test
     fun `already fresh names with suffixes are unchanged`() {
         val freshNameGenerator = FreshNameGenerator()
-        val x = freshNameGenerator.getFreshName("x_0")
-        val y = freshNameGenerator.getFreshName("y_1")
-        assertEquals("x_0", x)
-        assertEquals("y_1", y)
+        val x0 = freshNameGenerator.getFreshName("x_0")
+        val x1 = freshNameGenerator.getFreshName("x_1")
+        val y1 = freshNameGenerator.getFreshName("y_1")
+        val y0 = freshNameGenerator.getFreshName("y_0")
+        assertEquals("x_0", x0)
+        assertEquals("x_1", x1)
+        assertEquals("y_0", y0)
+        assertEquals("y_1", y1)
     }
 
     @Test
@@ -28,33 +32,42 @@ internal class FreshNameGeneratorTest {
         val freshNameGenerator = FreshNameGenerator()
         val name1 = freshNameGenerator.getFreshName("tmp")
         val name2 = freshNameGenerator.getFreshName("tmp")
+        val name3 = freshNameGenerator.getFreshName("tmp")
         assertNotEquals(name1, name2)
+        assertNotEquals(name1, name3)
+        assertNotEquals(name2, name3)
     }
 
     @Test
     fun `generated names with suffixes do not collide`() {
         val freshNameGenerator = FreshNameGenerator()
-        freshNameGenerator.getFreshName("tmp")
-        val name2: String = freshNameGenerator.getFreshName("tmp_1")
-        val name3: String = freshNameGenerator.getFreshName("tmp")
+        val name1 = freshNameGenerator.getFreshName("tmp")
+        val name2 = freshNameGenerator.getFreshName("tmp_1")
+        val name3 = freshNameGenerator.getFreshName("tmp")
+        assertNotEquals(name1, name2)
+        assertNotEquals(name1, name3)
         assertNotEquals(name2, name3)
     }
 
     @Test
     fun `generated names with suffixes do not collide 2`() {
         val freshNameGenerator = FreshNameGenerator()
-        freshNameGenerator.getFreshName("tmp")
-        val name2: String = freshNameGenerator.getFreshName("tmp_01")
-        val name3: String = freshNameGenerator.getFreshName("tmp")
+        val name1 = freshNameGenerator.getFreshName("tmp")
+        val name2 = freshNameGenerator.getFreshName("tmp")
+        val name3 = freshNameGenerator.getFreshName("tmp_1")
+        assertNotEquals(name1, name2)
+        assertNotEquals(name1, name3)
         assertNotEquals(name2, name3)
     }
 
     @Test
     fun `generated names with nested suffixes do not collide`() {
         val freshNameGenerator = FreshNameGenerator()
-        freshNameGenerator.getFreshName("tmp")
-        val name2: String = freshNameGenerator.getFreshName("tmp_1_0")
-        val name3: String = freshNameGenerator.getFreshName("tmp")
+        val name1 = freshNameGenerator.getFreshName("tmp")
+        val name2 = freshNameGenerator.getFreshName("tmp_1_0")
+        val name3 = freshNameGenerator.getFreshName("tmp")
+        assertNotEquals(name1, name2)
+        assertNotEquals(name1, name3)
         assertNotEquals(name2, name3)
     }
 }


### PR DESCRIPTION
I added examples showing that the fix to the fresh name generator isn't enough and applied a correct fix.

The idea is to record every single name returned by the name generator. Then, we can check that a supposedly fresh name is actually fresh. This increases the memory footprint, and makes `getFreshName` only amortized constant time (before, it was unconditionally constant). I don't think this matters given the sizes of our programs.

Closes #61