### PR TITLE
Fix parsing of host list

### DIFF
--- a/compiler/src/main/cup/edu/cornell/cs/apl/viaduct/parsing/Parser.cup
+++ b/compiler/src/main/cup/edu/cornell/cs/apl/viaduct/parsing/Parser.cup
@@ -589,8 +589,7 @@ host ::=
   ;
 
 host_list ::=
-    nonempty_host_list:hosts COMMA host:host {:
-      hosts.add(host);
+    nonempty_host_list:hosts {:
       RESULT = hosts;
     :}
 
@@ -600,7 +599,7 @@ host_list ::=
   ;
 
 nonempty_host_list ::=
-    nonempty_host_list:hosts host:host {:
+    nonempty_host_list:hosts COMMA host:host {:
       hosts.add(host);
       RESULT = hosts;
     :}


### PR DESCRIPTION
The structure of the `host_list` production is now changed to mirror that of `expr_list` and so on

Closes #78 