### PR TITLE
Use BuildKit to build Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1.2
+
+ARG APP=viaduct
 ARG JDK_VERSION=11.0.10
 
 # Build stage
@@ -8,24 +11,17 @@ WORKDIR /app
 ## Have Gradle Wrapper download the Gradle binary
 COPY gradlew .
 COPY gradle gradle
+COPY gradle.properties .
 RUN ./gradlew --version
 
-## Have Gradle download all dependencies
-COPY *.gradle.kts ./
-COPY cli/*.gradle.kts cli/
-COPY compiler/*.gradle.kts compiler/
-COPY runtime/*.gradle.kts runtime/
-COPY shared/*.gradle.kts shared/
-COPY test-utilities/*.gradle.kts test-utilities/
-RUN ./gradlew build
-
 ## Build the app
+COPY *.gradle.kts ./
 COPY cli cli
 COPY compiler compiler
 COPY runtime runtime
 COPY shared shared
 COPY test-utilities test-utilities
-RUN ./gradlew :cli:installDist
+RUN --mount=type=cache,target=/root/.gradle/caches ./gradlew --info :cli:installDist
 
 
 # Collect source files
@@ -45,6 +41,8 @@ FROM openjdk:${JDK_VERSION}-jdk-slim
 CMD ["/bin/bash"]
 WORKDIR /root
 
+ARG APP
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash-completion \
     iproute2 \
@@ -59,12 +57,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN echo source /etc/profile.d/bash_completion.sh >> .bashrc
 
 ## Copy application binary
-COPY --from=builder /app/cli/build/install /usr/local/
-RUN ["ln", "-s", "/usr/local/cli/bin/cli", "/usr/local/bin/viaduct" ]
+COPY --from=builder /app/cli/build/install/cli /usr/local/${APP}
+RUN ln -s /usr/local/${APP}/bin/cli /usr/local/bin/${APP}
 
 ## Add command-line completion (i.e. tab to autocomplete)
-RUN _VIADUCT_COMPLETE=bash viaduct > /etc/profile.d/viaduct_completion.sh
-RUN echo source /etc/profile.d/viaduct_completion.sh >> .bashrc
+RUN _VIADUCT_COMPLETE=bash ${APP} > /etc/profile.d/${APP}-completion.sh
+RUN echo source /etc/profile.d/${APP}-completion.sh >> .bashrc
 
 ## Copy benchmarks
 COPY benchmarks ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY compiler compiler
 COPY runtime runtime
 COPY shared shared
 COPY test-utilities test-utilities
-RUN --mount=type=cache,target=/root/.gradle/caches ./gradlew --info :cli:installDist
+RUN --mount=type=cache,target=/root/.gradle/caches ./gradlew :cli:installDist
 
 
 # Collect source files


### PR DESCRIPTION
BuildKit builder is like the default Docker builder but 100 times better.