### PR TITLE
only equivocate if you are not the sender of the data

### DIFF
--- a/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
+++ b/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
@@ -218,38 +218,64 @@ class PlaintextProtocolInterpreter(
                         }
                     }
 
-                    assert(cleartextValue != null)
+                    if (cleartextValue == null) {
+                        throw ViaductInterpreterError("Plaintext: received null value")
+                    }
 
-                    // check for equivocation
-                    val recvHosts: Set<Host> =
+                    // calculate set of hosts with whom [this.host] needs to check for equivocation
+                    val hostsToCheckWith: Set<Host> =
                         events
                             .filter { event ->
-                                event.recv.id == Plaintext.INPUT && event.send.host != event.recv.host &&
+                                // remove events where receiving host is not receiving plaintext data
+                                event.recv.id == Plaintext.INPUT &&
+
+                                    // remove events where a host is sending data to themselves
+                                    event.send.host != event.recv.host &&
+
+                                    // remove events where [this.host] is the sender of the data
                                     event.send.host != this.host
                             }
+
+                            // of events matching above criteria, get set of data receivers
                             .map { event -> event.recv.host }
+
+                            // remove [this.host] from the set of hosts with whom [this.host] needs to
+                            // check for equivocation
                             .filter { host -> host != this.host }
                             .toSet()
 
-                    for (recvHost in recvHosts) {
+                    if (hostsToCheckWith.isNotEmpty()) {
+                        logger.trace {
+                            "host: " + this.host.asDocument.print() + " checks for equivocation with: " +
+                                hostsToCheckWith.fold("") { acc, host -> host.asDocument.print() + ' ' + acc }
+                        }
+                    }
+
+                    for (host in hostsToCheckWith) {
                         runtime.send(
-                            cleartextValue!!,
+                            cleartextValue,
                             projection,
-                            ProtocolProjection(recvProtocol, recvHost)
+                            ProtocolProjection(recvProtocol, host)
                         )
                     }
 
-                    for (recvHost in recvHosts) {
+                    for (host in hostsToCheckWith) {
                         val recvValue =
                             runtime.receive(
-                                ProtocolProjection(recvProtocol, recvHost),
+                                ProtocolProjection(recvProtocol, host),
                                 projection
                             )
 
-                        assert(recvValue == cleartextValue)
+                        if (recvValue != cleartextValue) {
+                            throw ViaductInterpreterError(
+                                "equivocation error between hosts: " + this.host.asDocument.print() + ", " +
+                                    host.asDocument.print() + ", expected " + cleartextValue.asDocument.print() +
+                                    ", received " + recvValue.asDocument.print()
+                            )
+                        }
                     }
 
-                    tempStore = tempStore.put(sender.temporary.value, cleartextValue!!)
+                    tempStore = tempStore.put(sender.temporary.value, cleartextValue)
                 }
 
                 // commitment opening

--- a/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
+++ b/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
@@ -36,10 +36,10 @@ import edu.cornell.cs.apl.viaduct.syntax.types.ValueType
 import edu.cornell.cs.apl.viaduct.syntax.values.ByteVecValue
 import edu.cornell.cs.apl.viaduct.syntax.values.IntegerValue
 import edu.cornell.cs.apl.viaduct.syntax.values.Value
+import java.util.Stack
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 import mu.KotlinLogging
-import java.util.Stack
 
 private val logger = KotlinLogging.logger("Plaintext")
 
@@ -224,8 +224,8 @@ class PlaintextProtocolInterpreter(
                     val recvHosts: Set<Host> =
                         events
                             .filter { event ->
-                                event.recv.id == Plaintext.INPUT && event.send.host != event.recv.host
-                                    && event.send.host != this.host
+                                event.recv.id == Plaintext.INPUT && event.send.host != event.recv.host &&
+                                    event.send.host != this.host
                             }
                             .map { event -> event.recv.host }
                             .filter { host -> host != this.host }

--- a/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
+++ b/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
@@ -1,5 +1,6 @@
 package edu.cornell.cs.apl.viaduct.backend
 
+import edu.cornell.cs.apl.prettyprinting.joined
 import edu.cornell.cs.apl.viaduct.analysis.ProtocolAnalysis
 import edu.cornell.cs.apl.viaduct.backend.commitment.HashInfo
 import edu.cornell.cs.apl.viaduct.backend.commitment.encode
@@ -247,7 +248,7 @@ class PlaintextProtocolInterpreter(
                     if (hostsToCheckWith.isNotEmpty()) {
                         logger.trace {
                             "host: " + this.host.asDocument.print() + " checks for equivocation with: " +
-                                hostsToCheckWith.fold("") { acc, host -> host.asDocument.print() + ' ' + acc }
+                                hostsToCheckWith.sorted().joined().print()
                         }
                     }
 

--- a/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
+++ b/runtime/src/main/kotlin/edu/cornell/cs/apl/viaduct/backend/PlaintextProtocolInterpreter.kt
@@ -36,10 +36,10 @@ import edu.cornell.cs.apl.viaduct.syntax.types.ValueType
 import edu.cornell.cs.apl.viaduct.syntax.values.ByteVecValue
 import edu.cornell.cs.apl.viaduct.syntax.values.IntegerValue
 import edu.cornell.cs.apl.viaduct.syntax.values.Value
-import java.util.Stack
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 import mu.KotlinLogging
+import java.util.Stack
 
 private val logger = KotlinLogging.logger("Plaintext")
 
@@ -221,10 +221,12 @@ class PlaintextProtocolInterpreter(
                     assert(cleartextValue != null)
 
                     // check for equivocation
-                    /*
                     val recvHosts: Set<Host> =
                         events
-                            .filter { event -> event.recv.id == Plaintext.INPUT && event.send.host != event.recv.host }
+                            .filter { event ->
+                                event.recv.id == Plaintext.INPUT && event.send.host != event.recv.host
+                                    && event.send.host != this.host
+                            }
                             .map { event -> event.recv.host }
                             .filter { host -> host != this.host }
                             .toSet()
@@ -246,7 +248,6 @@ class PlaintextProtocolInterpreter(
 
                         assert(recvValue == cleartextValue)
                     }
-                    */
 
                     tempStore = tempStore.put(sender.temporary.value, cleartextValue!!)
                 }


### PR DESCRIPTION
Added an additional check to make sure that you only try to equivocate with other hosts for communication events for which you are not the sender of the data. Without this check, if Chuck sends data to Replicated(Chuck, Alice), Chuck will try to equivocate with Alice, whereas the current filtering won't have Alice try to equivocate with Chuck, causing Chuck's interpreter to hang. This fix removes Chuck's attempt to equivocate with Alice (which shouldn't happen as Chuck is the sender).