### PR TITLE
Bump Gradle to 7.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ subprojects {
 
         /** Java Version */
 
-        extensions.configure<JavaPluginExtension>("java") {
+        configure<JavaPluginExtension> {
             toolchain {
                 languageVersion.set(JavaLanguageVersion.of(11))
             }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -7,6 +7,12 @@ repositories {
     mavenCentral()
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 dependencies {
     implementation("edu.cornell.cs.apl:runtime2")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/runtime2/build.gradle.kts
+++ b/runtime2/build.gradle.kts
@@ -17,5 +17,5 @@ dependencies {
 }
 
 kotlin.sourceSets.all {
-    languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
+    languageSettings.optIn("kotlin.RequiresOptIn")
 }


### PR DESCRIPTION
Known problems:
- The `gradle-plugin` project complains about Kotlin version being set to `1.8`