### PR TITLE
Add task to generate a list of all Viaduct programs

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -70,6 +70,6 @@ abstract class GenerateViaductProgramList : DefaultTask() {
         val outputFile = outputDirectory.file("ViaductPrograms.kt").get().asFile
 
         val programsBlock = programs.map { "    $it" }.joinToString(",\n")
-        outputFile.writeText("val viaductPrograms = listOf(\n$programsBlock\n)")
+        outputFile.writeText("val viaductPrograms = listOf(\n$programsBlock\n)\n")
     }
 }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -30,3 +30,46 @@ spotless {
         ktlint()
     }
 }
+
+val generateViaductProgramList by tasks.registering(GenerateViaductProgramList::class) {
+    sourceDirectory.set(tasks.compileViaduct.map { it.sourceDirectory }.get())
+}
+
+kotlin.sourceSets.main {
+    kotlin.srcDir(generateViaductProgramList.map { it.outputDirectory })
+}
+
+abstract class GenerateViaductProgramList : DefaultTask() {
+    @get:InputDirectory
+    abstract val sourceDirectory: DirectoryProperty
+
+    @OutputDirectory
+    val outputDirectory: DirectoryProperty =
+        project.objects.directoryProperty().apply {
+            convention(project.layout.buildDirectory.dir("generated/sources/properties"))
+        }
+
+    @Internal
+    override fun getGroup(): String =
+        LifecycleBasePlugin.BUILD_TASK_NAME
+
+    @Internal
+    override fun getDescription(): String =
+        "Generates a list of all Viaduct compiled programs."
+
+    @TaskAction
+    fun generate() {
+        val source = sourceDirectory.get().asFile
+        val programs = source.walk().filter { it.isFile }.map {
+            val packageName = it.parentFile.toRelativeString(source).replace(File.separator, ".")
+            val className = it.nameWithoutExtension
+            if (packageName.isEmpty()) className else "$packageName.$className"
+        }.sorted()
+
+        outputDirectory.get().asFile.mkdirs()
+        val outputFile = outputDirectory.file("ViaductPrograms.kt").get().asFile
+
+        val programsBlock = programs.map { "    $it" }.joinToString(",\n")
+        outputFile.writeText("val viaductPrograms = listOf(\n$programsBlock\n)")
+    }
+}

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     kotlin("jvm") version embeddedKotlinVersion
     id("viaduct")
+
+    // Style checking
+    id("com.diffplug.spotless") version "6.2.0"
 }
 
 repositories {
@@ -15,4 +18,15 @@ java {
 
 dependencies {
     implementation("edu.cornell.cs.apl:runtime")
+}
+
+spotless {
+    kotlinGradle {
+        ktlint()
+    }
+    kotlin {
+        val relativeBuildPath = project.buildDir.relativeTo(project.projectDir)
+        targetExclude("$relativeBuildPath/**/*.kt")
+        ktlint()
+    }
 }


### PR DESCRIPTION
The `examples` project now automatically generates a file that contains a list of all Viaduct compiled programs. It looks like this:

```kotlin
// build/generated/sources/ViaductPrograms.kt

val viaductPrograms = listOf(
    Rochambeau,
    tests.CommitmentArray,
    tests.ControlFlow,
    tests.Equivocation,
    ...
)
```