### PR TITLE
Collect host declarations in generated code under an object

### DIFF
--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/backends/cleartext/CleartextCodeGenerator.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/backends/cleartext/CleartextCodeGenerator.kt
@@ -91,7 +91,11 @@ class CleartextCodeGenerator(context: CodeGeneratorContext) :
                             expr.operator,
                             exp(protocol, expr.arguments[1])
                         )
-                    else -> throw CodeGenerationError("unknown operator: ${expr.operator.toDocument(expr.arguments).print()}")
+                    else -> throw CodeGenerationError(
+                        "unknown operator: ${
+                        expr.operator.toDocument(expr.arguments).print()
+                        }"
+                    )
                 }
             }
 
@@ -305,12 +309,12 @@ class CleartextCodeGenerator(context: CodeGeneratorContext) :
                             clearTextTemp
                         )
                         receiveBuilder.addStatement(
-                            "throw %T(%L, %L, %L, %L)",
+                            "throw %T(%N, %L, %N, %L)",
                             EquivocationException::class.asClassName(),
                             clearTextTemp,
-                            cleartextInputs.first().send.host.name,
+                            context.codeOf(cleartextInputs.first().send.host),
                             receiveTmp,
-                            hostsToCheckWith.first().name
+                            context.codeOf(hostsToCheckWith.first())
 
                         )
                         receiveBuilder.endControlFlow()

--- a/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/codegeneration/CodeGeneratorContext.kt
+++ b/compiler/src/main/kotlin/edu/cornell/cs/apl/viaduct/codegeneration/CodeGeneratorContext.kt
@@ -19,8 +19,11 @@ interface CodeGeneratorContext {
 
     fun kotlinName(sourceName: ObjectVariable): String
 
-    // returns a fresh kotlin name for baseName
+    /** Returns a fresh kotlin name based on [baseName]. */
     fun newTemporary(baseName: String): String
+
+    /** Returns code that will evaluate to [host]. */
+    fun codeOf(host: Host): CodeBlock
 
     /** Returns code that will receive a value of type [type] from [sender]. */
     fun receive(type: TypeName, sender: Host): CodeBlock
@@ -28,5 +31,6 @@ interface CodeGeneratorContext {
     /** Returns code that will send [value] to [receiver]. */
     fun send(value: CodeBlock, receiver: Host): CodeBlock
 
+    /** Returns code that will evaluate to the address of [host]. */
     fun url(host: Host): CodeBlock
 }


### PR DESCRIPTION
Cached host declarations now look like this:

```kotlin
  private object Hosts {
    public val alice: Host = Host("alice")

    public val bob: Host = Host("bob")

    public val chuck: Host = Host("chuck")
  }
```

instead of this:

```kotlin
  public val alice: Host = Host("alice")

  public val bob: Host = Host("bob")

  public val chuck: Host = Host("chuck")
```