### PR TITLE
Disable ABY tests

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -28,7 +28,6 @@ jobs:
         with:
           arguments: printVersion build jacocoTestReport
       - name: Build example programs
-        if: runner.os != 'Windows'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: -p examples build

--- a/examples/src/test/kotlin/edu/cornell/cs/apl/viaduct/examples/RunExamplesTest.kt
+++ b/examples/src/test/kotlin/edu/cornell/cs/apl/viaduct/examples/RunExamplesTest.kt
@@ -26,18 +26,14 @@ internal class RunExamplesTest {
     @ParameterizedTest
     @ArgumentsSource(ViaductProgramProvider::class)
     fun `produces correct output`(program: ViaductGeneratedProgram) {
-        val outputs = program.run()
+        checkOutput(program)
+    }
 
-        program.hosts.forEach { host ->
-            println("${host.name} outputs:")
-            println(outputs.getValue(host))
-        }
-
-        program.hosts.forEach { host ->
-            val expectedOutput = parseOutput(outputFile(program, host).readText())
-            val actualOutput = parseOutput(outputs.getValue(host))
-            assertEquals(expectedOutput, actualOutput, host.name)
-        }
+    @Disabled
+    @ParameterizedTest
+    @ArgumentsSource(ViaductABYProgramProvider::class)
+    fun `aby program produces correct output`(program: ViaductGeneratedProgram) {
+        checkOutput(program)
     }
 
     /** Convenience function that creates empty input/output files for new test programs. */
@@ -62,6 +58,22 @@ internal class RunExamplesTest {
         fun setLogLevel() {
             Configurator.setRootLevel(Level.TRACE)
         }
+    }
+}
+
+/** Executes [program] and verifies that produces the expected output. */
+private fun checkOutput(program: ViaductGeneratedProgram) {
+    val outputs = program.run()
+
+    program.hosts.forEach { host ->
+        println("${host.name} outputs:")
+        println(outputs.getValue(host))
+    }
+
+    program.hosts.forEach { host ->
+        val expectedOutput = parseOutput(outputFile(program, host).readText())
+        val actualOutput = parseOutput(outputs.getValue(host))
+        assertEquals(expectedOutput, actualOutput, host.name)
     }
 }
 

--- a/examples/src/test/kotlin/edu/cornell/cs/apl/viaduct/examples/ViaductProgramProvider.kt
+++ b/examples/src/test/kotlin/edu/cornell/cs/apl/viaduct/examples/ViaductProgramProvider.kt
@@ -1,12 +1,22 @@
 package edu.cornell.cs.apl.viaduct.examples
 
+import edu.cornell.cs.apl.viaduct.runtime.ViaductGeneratedProgram
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import java.util.stream.Stream
 
-/** Enumerates [viaductPrograms]. */
+/** Enumerates [viaductPrograms] that do not use ABY. */
 class ViaductProgramProvider : ArgumentsProvider {
     override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
-        viaductPrograms.map { Arguments.of(it) }.stream()
+        viaductPrograms.filter { !usesABY(it) }.map { Arguments.of(it) }.stream()
 }
+
+/** Enumerates [viaductPrograms] that use ABY. */
+class ViaductABYProgramProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
+        viaductPrograms.filter { usesABY(it) }.map { Arguments.of(it) }.stream()
+}
+
+private fun usesABY(program: ViaductGeneratedProgram): Boolean =
+    program::class.qualifiedName!!.contains("aby")


### PR DESCRIPTION
ABY cannot run Windows and intermittently produces wrong output on other platforms causing tests to fail. This PR skips running example programs that use ABY by default. They can still be run manually.