### PR TITLE
Implement free distributive lattice checks with assumptions

### DIFF
--- a/compiler/src/main/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLattice.kt
+++ b/compiler/src/main/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLattice.kt
@@ -33,14 +33,14 @@ class FreeDistributiveLattice<A> private constructor(joinOfMeets: JoinOfMeets<A>
 
     fun lessThanOrEqualTo(that: FreeDistributiveLattice<A>, assumptions: List<LessThanOrEqualTo<A>>): Boolean {
         return this.joinOfMeets.all { given ->
-            val firstApplicable = assumptions.indexOfFirst { it.isApplicable(given) }
-            if (firstApplicable == -1) {
+            val (applicable, inapplicable) = assumptions.partition { it.isApplicable(given) }
+            if (applicable.isEmpty()) {
                 that.joinOfMeets.any { required -> given.containsAll(required) }
             } else {
-                val givenAsLattice = FreeDistributiveLattice(persistentSetOf(given))
-                val newAssumptions = assumptions.toMutableList()
-                newAssumptions.removeAt(firstApplicable)
-                (givenAsLattice meet assumptions[firstApplicable].to).lessThanOrEqualTo(that, newAssumptions)
+                applicable
+                    .map { it.to }
+                    .fold(FreeDistributiveLattice(persistentSetOf(given)), FreeDistributiveLattice<A>::meet)
+                    .lessThanOrEqualTo(that, inapplicable)
             }
         }
     }

--- a/compiler/src/main/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLattice.kt
+++ b/compiler/src/main/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLattice.kt
@@ -21,9 +21,8 @@ class FreeDistributiveLattice<A> private constructor(joinOfMeets: JoinOfMeets<A>
 
     constructor(element: A) : this(persistentSetOf(persistentSetOf(element)))
 
-    override fun lessThanOrEqualTo(that: FreeDistributiveLattice<A>): Boolean {
-        return this.join(that) == that
-    }
+    override fun lessThanOrEqualTo(that: FreeDistributiveLattice<A>): Boolean =
+        this.lessThanOrEqualTo(that, listOf())
 
     /**
      * Represents the assumption that [from] is below [to].

--- a/compiler/src/test/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLatticeTest.kt
+++ b/compiler/src/test/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLatticeTest.kt
@@ -36,6 +36,8 @@ internal class FreeDistributiveLatticeTest {
         @Test
         fun simple() {
             assertFlowsTo(a, b, a to b)
+            assertFlowsTo(a, c, a to b, b to c)
+            assertFlowsTo(a, c, b to c, a to b)
         }
 
         @Test

--- a/compiler/src/test/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLatticeTest.kt
+++ b/compiler/src/test/kotlin/io/github/apl_cornell/viaduct/algebra/FreeDistributiveLatticeTest.kt
@@ -1,32 +1,77 @@
 package io.github.apl_cornell.viaduct.algebra
 
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class FreeDistributiveLatticeTest {
-    private val elemA = FreeDistributiveLattice("a")
-    private val elemB = FreeDistributiveLattice("b")
-    private val elemC = FreeDistributiveLattice("c")
+    private val a = FreeDistributiveLattice("a")
+    private val b = FreeDistributiveLattice("b")
+    private val c = FreeDistributiveLattice("c")
     private val top = FreeDistributiveLattice.bounds<String>().top
     private val bottom = FreeDistributiveLattice.bounds<String>().bottom
 
     @Test
-    fun testImply() {
+    fun imply() {
         /* For all y, the greatest x s.t. bottom & x <= y is top. */
-        Assertions.assertEquals(top, bottom.imply(elemA))
+        Assertions.assertEquals(top, bottom.imply(a))
 
         /* For all y, the greatest x s.t. y & x <= y is top. */
-        Assertions.assertEquals(top, elemA.imply(elemA))
-        Assertions.assertEquals(elemB, elemA.imply(elemB))
-        Assertions.assertEquals(elemB, elemA.imply(elemB.meet(elemA)))
-        Assertions.assertEquals(top, elemB.join(elemA).imply(elemA.join(elemB)))
-        Assertions.assertEquals(elemA, elemA.join(elemB).imply(elemA))
-        Assertions.assertEquals(top, elemA.meet(elemB).imply(elemA))
-        Assertions.assertEquals(top, elemA.imply(top))
-        Assertions.assertEquals(bottom, elemA.imply(bottom))
-        Assertions.assertEquals(top, elemA.imply(elemA.join(elemB)))
-        Assertions.assertEquals(elemA.imply(elemB).meet(elemA.imply(elemC)), elemA.imply(elemB.meet(elemC)))
-        Assertions.assertEquals(elemA.meet(elemB), elemA.meet(elemA.imply(elemB)))
-        Assertions.assertEquals(elemB, elemB.meet(elemA.imply(elemB)))
+        Assertions.assertEquals(top, a.imply(a))
+        Assertions.assertEquals(b, a.imply(b))
+        Assertions.assertEquals(b, a.imply(b.meet(a)))
+        Assertions.assertEquals(top, b.join(a).imply(a.join(b)))
+        Assertions.assertEquals(a, a.join(b).imply(a))
+        Assertions.assertEquals(top, a.meet(b).imply(a))
+        Assertions.assertEquals(top, a.imply(top))
+        Assertions.assertEquals(bottom, a.imply(bottom))
+        Assertions.assertEquals(top, a.imply(a.join(b)))
+        Assertions.assertEquals(a.imply(b).meet(a.imply(c)), a.imply(b.meet(c)))
+        Assertions.assertEquals(a.meet(b), a.meet(a.imply(b)))
+        Assertions.assertEquals(b, b.meet(a.imply(b)))
+    }
+
+    @Nested
+    inner class Assumptions {
+        @Test
+        fun simple() {
+            assertFlowsTo(a, b, a to b)
+        }
+
+        @Test
+        fun `join left`() {
+            assertFlowsTo(a join b, c, a to c, b to c)
+            assertFlowsTo(a join b, c, (a join b) to c)
+        }
+
+        @Test
+        fun `join right`() {
+            assertFlowsTo(a, b join c, a to b)
+            assertFlowsTo(a, b join c, a to (b join c))
+        }
+
+        @Test
+        fun `meet left`() {
+            assertFlowsTo(a meet b, c, a to c)
+            assertFlowsTo(a meet b, c, (a meet b) to c)
+        }
+
+        @Test
+        fun `meet right`() {
+            assertFlowsTo(a, b meet c, a to b, a to c)
+            assertFlowsTo(a, b meet c, a to (b meet c))
+        }
+    }
+
+    companion object {
+        private fun <A> assertFlowsTo(
+            from: FreeDistributiveLattice<A>,
+            to: FreeDistributiveLattice<A>,
+            vararg assumptions: Pair<FreeDistributiveLattice<A>, FreeDistributiveLattice<A>>
+        ) {
+            val assumptionsList = assumptions.map { FreeDistributiveLattice.LessThanOrEqualTo(it.first, it.second) }
+            Assertions.assertFalse(from.lessThanOrEqualTo(to))
+            Assertions.assertTrue(from.lessThanOrEqualTo(to, assumptionsList))
+        }
     }
 }


### PR DESCRIPTION
We can now check whether `l_1 flowsTo l_2` under the assumptions `a_1 flowsTo b_1, ..., a_n flowsTo b_n`.