### PR TITLE
Replace boilerplate code with reflection for `AnalysisProvider`

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(project(":shared"))
     implementation(project(":runtime"))
 
+    // Kotlin
     implementation(kotlin("reflect"))
 
     // Data structures

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
     implementation(project(":shared"))
     implementation(project(":runtime"))
 
+    implementation(kotlin("reflect"))
+
     // Data structures
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.5")
     implementation("com.uchuhimo:kotlinx-bimap:1.2")
@@ -41,7 +43,6 @@ dependencies {
 
     // Testing
     testImplementation(project(":test-utilities"))
-    testImplementation(kotlin("reflect"))
 }
 
 /** Compilation */

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/Analysis.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/Analysis.kt
@@ -1,4 +1,14 @@
 package io.github.aplcornell.viaduct.analysis
 
-/** An analysis over [Node]. */
+/**
+ * A class that computes information about a [Node].
+ * The information should be completely determined given the [Node].
+ * That is, an [Analysis] should act like a pure function from [Node]
+ * to some metadata.
+ *
+ * It is common to need the same analysis at multiple places in a compiler.
+ * For example, type information might be useful for different passes.
+ * Recompute type information over and over again would be inefficient.
+ * @see AnalysisProvider for a way to cache [Analysis] instances.
+ */
 interface Analysis<Node>

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/Analysis.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/Analysis.kt
@@ -1,0 +1,4 @@
+package io.github.aplcornell.viaduct.analysis
+
+/** An analysis over [Node]. */
+interface Analysis<Node>

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/AnalysisProvider.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/AnalysisProvider.kt
@@ -1,12 +1,44 @@
 package io.github.aplcornell.viaduct.analysis
 
-import io.github.aplcornell.viaduct.syntax.intermediate.ProgramNode
+import io.github.aplcornell.viaduct.attributes.Tree
+import io.github.aplcornell.viaduct.attributes.TreeNode
+import io.github.aplcornell.viaduct.attributes.attribute
+import mu.KotlinLogging
+import kotlin.reflect.KClass
 
-interface AnalysisProvider<Analysis> {
+private val logger = KotlinLogging.logger("AnalysisProvider")
+
+class AnalysisProvider<Node : TreeNode<Node>, RootNode : Node>(rootNode: RootNode) {
+    /** A lazily constructed [Tree] instance for the root node. */
+    val tree: Tree<Node, RootNode> by lazy { Tree(rootNode) }
+
+    val KClass<Analysis<RootNode>>.instance: Analysis<RootNode> by attribute {
+        logger.debug("Constructing instance for $this")
+        val constructor = this.constructors.first()
+        val arguments = constructor.parameters.map {
+            when (it.type.classifier) {
+                rootNode::class -> {
+                    rootNode
+                }
+
+                tree::class -> {
+                    tree
+                }
+
+                else -> {
+                    @Suppress("UNCHECKED_CAST")
+                    (it.type.classifier as KClass<Analysis<RootNode>>).instance
+                }
+            }
+        }
+        constructor.call(*arguments.toTypedArray())
+    }
+
     /**
-     * Returns the [Analysis] instance for [program].
-     * The returned instance is cached for efficiency, so calling [get] again on [program] will
-     * return the same instance.
+     * Returns the [Analysis] instance for the root node.
+     * The returned instance is cached for efficiency, so calling [get] again will return the same instance.
      */
-    fun get(program: ProgramNode): Analysis
+    inline fun <reified A : Analysis<RootNode>> get(): A =
+        @Suppress("UNCHECKED_CAST")
+        (A::class as KClass<Analysis<RootNode>>).instance as A
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/AnalysisProvider.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/AnalysisProvider.kt
@@ -13,7 +13,7 @@ class AnalysisProvider<Node : TreeNode<Node>, RootNode : Node>(rootNode: RootNod
     val tree: Tree<Node, RootNode> by lazy { Tree(rootNode) }
 
     val KClass<Analysis<RootNode>>.instance: Analysis<RootNode> by attribute {
-        logger.debug("Constructing instance for $this")
+        logger.debug("Constructing instance for $this.")
         val constructor = this.constructors.first()
         val arguments = constructor.parameters.map {
             when (it.type.classifier) {

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/AnalysisProvider.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/AnalysisProvider.kt
@@ -5,16 +5,27 @@ import io.github.aplcornell.viaduct.attributes.TreeNode
 import io.github.aplcornell.viaduct.attributes.attribute
 import mu.KotlinLogging
 import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
 
 private val logger = KotlinLogging.logger("AnalysisProvider")
 
+/**
+ * Constructs and caches [Analysis] instances for a [RootNode] so that
+ * the same instance can be retrieved at multiple places in the compiler.
+ * This avoids recomputing the same information over and over again.
+ *
+ * This class uses reflection to construct [Analysis] instances.
+ * Each [Analysis] class must have a primary constructor. The constructor
+ * may have parameters of type: [TreeNode], [RootNode], and subclasses of [Analysis].
+ * Sensible arguments will be passed to the constructor based on parameter types.
+ */
 class AnalysisProvider<Node : TreeNode<Node>, RootNode : Node>(rootNode: RootNode) {
     /** A lazily constructed [Tree] instance for the root node. */
     val tree: Tree<Node, RootNode> by lazy { Tree(rootNode) }
 
     val KClass<Analysis<RootNode>>.instance: Analysis<RootNode> by attribute {
         logger.debug("Constructing instance for $this.")
-        val constructor = this.constructors.first()
+        val constructor = this.primaryConstructor!!
         val arguments = constructor.parameters.map {
             when (it.type.classifier) {
                 rootNode::class -> {

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/HostTrustConfiguration.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/HostTrustConfiguration.kt
@@ -1,8 +1,7 @@
-package io.github.aplcornell.viaduct.syntax
+package io.github.aplcornell.viaduct.analysis
 
 import io.github.aplcornell.viaduct.algebra.FreeDistributiveLattice
 import io.github.aplcornell.viaduct.algebra.FreeDistributiveLatticeCongruence
-import io.github.aplcornell.viaduct.analysis.AnalysisProvider
 import io.github.aplcornell.viaduct.passes.PrincipalComponent
 import io.github.aplcornell.viaduct.security.Component
 import io.github.aplcornell.viaduct.security.ConfidentialityComponent
@@ -16,8 +15,7 @@ import io.github.aplcornell.viaduct.syntax.intermediate.HostDeclarationNode
 import io.github.aplcornell.viaduct.syntax.intermediate.ProgramNode
 
 /** A map that associates each host with its authority label. */
-class HostTrustConfiguration private constructor(val program: ProgramNode) {
-
+class HostTrustConfiguration internal constructor(val program: ProgramNode) : Analysis<ProgramNode> {
     val congruence: FreeDistributiveLatticeCongruence<Component<Principal>> =
         FreeDistributiveLatticeCongruence(
             program.filterIsInstance<AuthorityDelegationDeclarationNode>()
@@ -32,13 +30,5 @@ class HostTrustConfiguration private constructor(val program: ProgramNode) {
 
     fun actsFor(from: Label, to: Label) = actsFor(from, to, congruence)
 
-    fun equals(from: Label, to: Label) =
-        actsFor(from, to) && actsFor(to, from)
-
-    companion object : AnalysisProvider<HostTrustConfiguration> {
-        private fun construct(program: ProgramNode) =
-            HostTrustConfiguration(program)
-
-        override fun get(program: ProgramNode): HostTrustConfiguration = program.cached(::construct)
-    }
+    fun equals(from: Label, to: Label) = actsFor(from, to) && actsFor(to, from)
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/InformationFlowAnalysis.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/InformationFlowAnalysis.kt
@@ -38,7 +38,6 @@ import io.github.aplcornell.viaduct.security.solver.flowsTo
 import io.github.aplcornell.viaduct.security.solver.integrityFlowsTo
 import io.github.aplcornell.viaduct.security.solver.term
 import io.github.aplcornell.viaduct.syntax.HasSourceLocation
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 import io.github.aplcornell.viaduct.syntax.Variable
 import io.github.aplcornell.viaduct.syntax.intermediate.AssertionNode
 import io.github.aplcornell.viaduct.syntax.intermediate.BlockNode
@@ -122,10 +121,11 @@ private sealed class LabelVariable {
 }
 
 /** Associates [Variable]s with their [Label]s. */
-class InformationFlowAnalysis private constructor(
+class InformationFlowAnalysis internal constructor(
     private val tree: Tree<Node, ProgramNode>,
     private val nameAnalysis: NameAnalysis,
-) {
+    private val trustConfiguration: HostTrustConfiguration,
+) : Analysis<ProgramNode> {
     private val FunctionDeclarationNode.constraintSystem: LabelConstraintSystem by attribute {
         constraints()
     }
@@ -133,8 +133,6 @@ class InformationFlowAnalysis private constructor(
     private val FunctionDeclarationNode.solution: Solution by attribute {
         constraintSystem.solution()
     }
-
-    private val trustConfiguration: HostTrustConfiguration = HostTrustConfiguration.get(tree.root)
 
     // private val solution by lazy { constraintSystem.solution() }
 
@@ -673,12 +671,5 @@ class InformationFlowAnalysis private constructor(
         tree.root.functions.forEach {
             it.constraintSystem.exportDotGraph(output)
         }
-    }
-
-    companion object : AnalysisProvider<InformationFlowAnalysis> {
-        private fun construct(program: ProgramNode) =
-            InformationFlowAnalysis(program.tree, NameAnalysis.get(program))
-
-        override fun get(program: ProgramNode): InformationFlowAnalysis = program.cached(::construct)
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/NameAnalysis.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/NameAnalysis.kt
@@ -70,7 +70,7 @@ import kotlin.reflect.KProperty
  * For example, [Temporary] variables are associated with [LetNode]s, [ObjectVariable]s with
  * [DeclarationNode]s, and [JumpLabel]s with [InfiniteLoopNode]s.
  * */
-class NameAnalysis private constructor(private val tree: Tree<Node, ProgramNode>) {
+class NameAnalysis internal constructor(private val tree: Tree<Node, ProgramNode>) : Analysis<ProgramNode> {
     /** Host declarations in scope for this node. */
     private val Node.hostDeclarations: NameMap<Host, HostDeclarationNode> by attribute {
         when (val parent = tree.parent(this)) {
@@ -654,11 +654,5 @@ class NameAnalysis private constructor(private val tree: Tree<Node, ProgramNode>
             node.children.forEach(::check)
         }
         check(tree.root)
-    }
-
-    companion object : AnalysisProvider<NameAnalysis> {
-        private fun construct(program: ProgramNode) = NameAnalysis(program.tree)
-
-        override fun get(program: ProgramNode): NameAnalysis = program.cached(::construct)
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/OutParameterInitializationAnalysis.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/OutParameterInitializationAnalysis.kt
@@ -55,10 +55,10 @@ private fun meet(
  * Analysis that ensures all out parameters of functions are initialized before
  * they are used and before the function returns.
  */
-class OutParameterInitializationAnalysis private constructor(
+class OutParameterInitializationAnalysis internal constructor(
     private val tree: Tree<Node, ProgramNode>,
     private val nameAnalysis: NameAnalysis,
-) {
+) : Analysis<ProgramNode> {
     /** Defines initialization map of out parameters BEFORE node has been executed. */
     private val Node.flowIn: PersistentMap<ObjectVariable, InitializationState> by attribute {
         val parent = tree.parent(this)
@@ -174,13 +174,5 @@ class OutParameterInitializationAnalysis private constructor(
     /** Begin check at ProgramNode [tree]. */
     fun check() {
         check(tree.root)
-    }
-
-    companion object : AnalysisProvider<OutParameterInitializationAnalysis> {
-        private fun construct(program: ProgramNode) =
-            OutParameterInitializationAnalysis(program.tree, NameAnalysis.get(program))
-
-        override fun get(program: ProgramNode): OutParameterInitializationAnalysis =
-            program.cached(::construct)
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/ProtocolAnalysis.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/analysis/ProtocolAnalysis.kt
@@ -43,8 +43,8 @@ class ProtocolAnalysis(
     val program: ProgramNode,
     private val protocolComposer: ProtocolComposer,
 ) {
-    private val tree = program.tree
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val tree = program.analyses.tree
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
 
     /** The outermost block this [Node] is in. */
     private val Node.enclosingBody: BlockNode by attribute {
@@ -164,11 +164,14 @@ class ProtocolAnalysis(
 
             is IfNode ->
                 thenBranch.protocols.addAll(elseBranch.protocols)
+
             is InfiniteLoopNode ->
                 body.protocols
+
             is BreakNode ->
                 // Every protocol executing the loop executes the breaks in the loop.
                 nameAnalysis.correspondingLoop(this).protocols
+
             is AssertionNode ->
                 // All protocols execute every assertion.
                 this.enclosingBody.protocols

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/aby/ABYCodeGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/aby/ABYCodeGenerator.kt
@@ -67,9 +67,9 @@ private data class ABYPair(val server: Host, val client: Host)
 class ABYCodeGenerator(
     context: CodeGeneratorContext,
 ) : AbstractCodeGenerator(context) {
-    private val typeAnalysis: TypeAnalysis = TypeAnalysis.get(context.program)
-    private val nameAnalysis: NameAnalysis = NameAnalysis.get(context.program)
-    private val protocolAnalysis: ProtocolAnalysis = ProtocolAnalysis(context.program, context.protocolComposer)
+    private val typeAnalysis = context.program.analyses.get<TypeAnalysis>()
+    private val nameAnalysis = context.program.analyses.get<NameAnalysis>()
+    private val protocolAnalysis = ProtocolAnalysis(context.program, context.protocolComposer)
     private var protocolToABYPartyMap: MutableMap<ABYPair, String> = mutableMapOf()
 
     companion object {

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/aby/ABYProtocolFactory.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/aby/ABYProtocolFactory.kt
@@ -38,7 +38,7 @@ import io.github.aplcornell.viaduct.util.pairedWith
 //      every break for that loop has a pc that flows to pc of selection
 
 class ABYProtocolFactory(program: ProgramNode) : ProtocolFactory {
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
 
     // hack to get backpointer to parent factory
     var parentFactory: ProtocolFactory? = null

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/cleartext/CleartextCodeGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/cleartext/CleartextCodeGenerator.kt
@@ -36,8 +36,8 @@ import io.github.aplcornell.viaduct.syntax.types.MutableCellType
 import io.github.aplcornell.viaduct.syntax.types.VectorType
 
 class CleartextCodeGenerator(context: CodeGeneratorContext) : AbstractCodeGenerator(context) {
-    private val typeAnalysis = TypeAnalysis.get(context.program)
-    private val nameAnalysis = NameAnalysis.get(context.program)
+    private val nameAnalysis = context.program.analyses.get<NameAnalysis>()
+    private val typeAnalysis = context.program.analyses.get<TypeAnalysis>()
 
     override fun guard(protocol: Protocol, expr: AtomicExpressionNode): CodeBlock =
         cleartextExp(protocol, expr)
@@ -55,6 +55,7 @@ class CleartextCodeGenerator(context: CodeGeneratorContext) : AbstractCodeGenera
                             exp(protocol, expr.arguments[0]),
                             exp(protocol, expr.arguments[1]),
                         )
+
                     Maximum ->
                         CodeBlock.of(
                             "%M(%L, %L)",
@@ -62,12 +63,14 @@ class CleartextCodeGenerator(context: CodeGeneratorContext) : AbstractCodeGenera
                             exp(protocol, expr.arguments[0]),
                             exp(protocol, expr.arguments[1]),
                         )
+
                     is UnaryOperator ->
                         CodeBlock.of(
                             "%L%L",
                             expr.operator.toString(),
                             exp(protocol, expr.arguments[0]),
                         )
+
                     is BinaryOperator ->
                         CodeBlock.of(
                             "%L %L %L",
@@ -75,6 +78,7 @@ class CleartextCodeGenerator(context: CodeGeneratorContext) : AbstractCodeGenera
                             expr.operator,
                             exp(protocol, expr.arguments[1]),
                         )
+
                     else -> throw UnsupportedOperatorException(protocol, expr)
                 }
             }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentCreatorGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentCreatorGenerator.kt
@@ -26,7 +26,7 @@ import io.github.aplcornell.viaduct.syntax.types.ValueType
 internal class CommitmentCreatorGenerator(
     context: CodeGeneratorContext,
 ) : AbstractCodeGenerator(context) {
-    private val typeAnalysis = TypeAnalysis.get(context.program)
+    private val typeAnalysis = context.program.analyses.get<TypeAnalysis>()
 
     override fun kotlinType(protocol: Protocol, sourceType: ValueType): TypeName =
         (Committed::class).asTypeName().parameterizedBy(typeTranslator(sourceType))

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentHolderGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentHolderGenerator.kt
@@ -26,7 +26,7 @@ import io.github.aplcornell.viaduct.backends.commitment.Commitment as Commitment
 internal class CommitmentHolderGenerator(
     context: CodeGeneratorContext,
 ) : AbstractCodeGenerator(context) {
-    private val typeAnalysis: TypeAnalysis = TypeAnalysis.get(context.program)
+    private val typeAnalysis = context.program.analyses.get<TypeAnalysis>()
 
     override fun kotlinType(protocol: Protocol, sourceType: ValueType): TypeName =
         (Commitment::class).asTypeName().parameterizedBy(typeTranslator(sourceType))

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentProtocolFactory.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentProtocolFactory.kt
@@ -15,7 +15,7 @@ import io.github.aplcornell.viaduct.syntax.intermediate.VariableDeclarationNode
 import io.github.aplcornell.viaduct.util.subsequences
 
 class CommitmentProtocolFactory(val program: ProgramNode) : ProtocolFactory {
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
 
     private val protocols: Set<Protocol> = run {
         val hostSubsets = program.hosts.sorted().subsequences().map { it.toSet() }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/zkp/ZKPProtocolFactory.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/zkp/ZKPProtocolFactory.kt
@@ -34,7 +34,7 @@ import io.github.aplcornell.viaduct.syntax.operators.Or
 import io.github.aplcornell.viaduct.util.subsequences
 
 class ZKPProtocolFactory(val program: ProgramNode) : ProtocolFactory {
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
 
     private val protocols: Set<Protocol> = run {
         val hostSubsets = program.hosts.sorted().subsequences().map { it.toSet() }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/codegeneration/BackendCodeGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/codegeneration/BackendCodeGenerator.kt
@@ -61,8 +61,8 @@ private class BackendCodeGenerator(
     val protocolComposer: ProtocolComposer,
     val hostDeclarations: TypeSpec,
 ) {
-    private val typeAnalysis = TypeAnalysis.get(program)
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
+    private val typeAnalysis = program.analyses.get<TypeAnalysis>()
     private val protocolAnalysis = ProtocolAnalysis(program, protocolComposer)
     private val context = Context()
     private val codeGenerator = codeGenerator(context)
@@ -238,6 +238,7 @@ private class BackendCodeGenerator(
                             is LiteralNode -> {
                                 CodeBlock.of("%L", guard.value)
                             }
+
                             is ReadNode -> {
                                 val guardProtocol = protocolAnalysis.primaryProtocol(guard)
                                 codeGenerator.guard(guardProtocol, guard)
@@ -281,6 +282,7 @@ private class BackendCodeGenerator(
             is ObjectReferenceArgumentNode -> {
                 CodeBlock.of("%N", context.kotlinName(argument.variable.value))
             }
+
             is ExpressionArgumentNode -> {
                 codeGenerator.exp(protocol, argument.expression)
             }
@@ -288,6 +290,7 @@ private class BackendCodeGenerator(
             is ObjectDeclarationArgumentNode -> {
                 throw UnsupportedOperatorException(protocol, argument)
             }
+
             is OutParameterArgumentNode -> { // Out box already in scope
                 CodeBlock.of("%N", outBoxName(argument.parameter.value))
             }
@@ -329,6 +332,7 @@ private class BackendCodeGenerator(
                 init.objectType,
                 init.arguments,
             )
+
             is OutParameterExpressionInitializerNode -> codeGenerator.exp(protocol, init.expression)
         }
         val parameterName = context.kotlinName(stmt.name.value)

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Checking.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Checking.kt
@@ -17,11 +17,13 @@ private val logger = KotlinLogging.logger("Check")
  * @throws CompilationError if there are errors in the program.
  */
 fun ProgramNode.check() {
-    logger.duration("name analysis") { NameAnalysis.get(this).check() }
+    logger.duration("name analysis") { analyses.get<NameAnalysis>().check() }
 
-    logger.duration("type analysis") { TypeAnalysis.get(this).check() }
+    logger.duration("type analysis") { analyses.get<TypeAnalysis>().check() }
 
-    logger.duration("out parameter initialization analysis") { OutParameterInitializationAnalysis.get(this).check() }
+    logger.duration("out parameter initialization analysis") {
+        analyses.get<OutParameterInitializationAnalysis>().check()
+    }
 
-    logger.duration("information flow analysis") { InformationFlowAnalysis.get(this).check() }
+    logger.duration("information flow analysis") { analyses.get<InformationFlowAnalysis>().check() }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Compilation.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Compilation.kt
@@ -50,7 +50,7 @@ fun SourceFile.compile(
         }
 
         // Dump label constraint graph.
-        saveLabelConstraintGraph?.invoke(InformationFlowAnalysis.get(elaborated)::exportConstraintGraph)
+        saveLabelConstraintGraph?.invoke(elaborated.analyses.get<InformationFlowAnalysis>()::exportConstraintGraph)
 
         // Perform static checks.
         elaborated.check()
@@ -67,7 +67,7 @@ fun SourceFile.compile(
 
     // Dump program annotated with inferred labels.
     if (saveInferredLabels != null) {
-        val ifcAnalysis = InformationFlowAnalysis.get(program)
+        val ifcAnalysis = program.analyses.get<InformationFlowAnalysis>()
         val labelMetadata: Metadata =
             (
                 program.descendantsIsInstance<LetNode>()

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Multiplexing.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Multiplexing.kt
@@ -80,7 +80,7 @@ class MuxPostprocessor(
     val selection: ProtocolAssignment,
 ) : ProgramPostprocessor {
     override fun postprocess(program: ProgramNode): ProgramNode {
-        val nameAnalysis = NameAnalysis.get(program)
+        val nameAnalysis = program.analyses.get<NameAnalysis>()
         return ProgramNode(
             program.declarations.map { declaration ->
                 when (declaration) {

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/ProtocolAnnotation.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/ProtocolAnnotation.kt
@@ -22,7 +22,7 @@ fun ProgramNode.annotateWithProtocols(assignment: ProtocolAssignment): ProgramNo
 
 /** Annotate AST with protocol assignment. */
 private class ProtocolAnnotator(val program: ProgramNode, val selection: ProtocolAssignment) {
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
 
     fun run(stmt: StatementNode): StatementNode {
         return when (stmt) {

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Rewrite.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Rewrite.kt
@@ -1,6 +1,7 @@
 package io.github.aplcornell.viaduct.passes
 
 import io.github.aplcornell.viaduct.algebra.FreeDistributiveLattice
+import io.github.aplcornell.viaduct.analysis.HostTrustConfiguration
 import io.github.aplcornell.viaduct.security.ConfidentialityComponent
 import io.github.aplcornell.viaduct.security.HostPrincipal
 import io.github.aplcornell.viaduct.security.IntegrityComponent
@@ -18,7 +19,6 @@ import io.github.aplcornell.viaduct.security.LabelParameter
 import io.github.aplcornell.viaduct.security.LabelTop
 import io.github.aplcornell.viaduct.security.PolymorphicPrincipal
 import io.github.aplcornell.viaduct.security.interpret
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 
 class Rewrite(
     private val rewrites: Map<PrincipalComponent, LabelConstant>,

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Specialization.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/passes/Specialization.kt
@@ -1,6 +1,7 @@
 package io.github.aplcornell.viaduct.passes
 
 import io.github.aplcornell.viaduct.algebra.FreeDistributiveLattice
+import io.github.aplcornell.viaduct.analysis.HostTrustConfiguration
 import io.github.aplcornell.viaduct.analysis.InformationFlowAnalysis
 import io.github.aplcornell.viaduct.analysis.main
 import io.github.aplcornell.viaduct.security.Component
@@ -11,7 +12,6 @@ import io.github.aplcornell.viaduct.security.PolymorphicPrincipal
 import io.github.aplcornell.viaduct.security.Principal
 import io.github.aplcornell.viaduct.syntax.Arguments
 import io.github.aplcornell.viaduct.syntax.FunctionName
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 import io.github.aplcornell.viaduct.syntax.LabelNode
 import io.github.aplcornell.viaduct.syntax.Located
 import io.github.aplcornell.viaduct.syntax.ObjectTypeNode
@@ -78,8 +78,8 @@ private class Specializer(
     // old main program
     private val mainProgram: BlockNode = program.main.body
 
-    private val informationFlowAnalysis = InformationFlowAnalysis.get(program)
-    private val hostTrustConfiguration = HostTrustConfiguration.get(program)
+    private val hostTrustConfiguration = program.analyses.get<HostTrustConfiguration>()
+    private val informationFlowAnalysis = program.analyses.get<InformationFlowAnalysis>()
 
     // worklist identified by new functions and corresponding old functionCallNode to be specialized
     private val worklist: MutableList<Triple<FunctionName, FunctionCallNode, Rewrite>> =

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/security/LabelExpression.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/security/LabelExpression.kt
@@ -1,13 +1,13 @@
 package io.github.aplcornell.viaduct.security
 
 import io.github.aplcornell.viaduct.algebra.FreeDistributiveLattice
+import io.github.aplcornell.viaduct.analysis.HostTrustConfiguration
 import io.github.aplcornell.viaduct.prettyprinting.Document
 import io.github.aplcornell.viaduct.prettyprinting.PrettyPrintable
 import io.github.aplcornell.viaduct.prettyprinting.plus
 import io.github.aplcornell.viaduct.prettyprinting.times
 import io.github.aplcornell.viaduct.prettyprinting.tupled
 import io.github.aplcornell.viaduct.syntax.Host
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 import io.github.aplcornell.viaduct.syntax.LabelVariable
 
 sealed class LabelExpression : PrettyPrintable {

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/selection/SelectionConstraintGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/selection/SelectionConstraintGenerator.kt
@@ -1,5 +1,6 @@
 package io.github.aplcornell.viaduct.selection
 
+import io.github.aplcornell.viaduct.analysis.HostTrustConfiguration
 import io.github.aplcornell.viaduct.analysis.InformationFlowAnalysis
 import io.github.aplcornell.viaduct.analysis.NameAnalysis
 import io.github.aplcornell.viaduct.analysis.descendantsIsInstance
@@ -9,7 +10,6 @@ import io.github.aplcornell.viaduct.errors.InvalidProtocolAnnotationError
 import io.github.aplcornell.viaduct.errors.NoApplicableProtocolError
 import io.github.aplcornell.viaduct.errors.NoSelectionSolutionError
 import io.github.aplcornell.viaduct.syntax.Host
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 import io.github.aplcornell.viaduct.syntax.Protocol
 import io.github.aplcornell.viaduct.syntax.intermediate.AssertionNode
 import io.github.aplcornell.viaduct.syntax.intermediate.BlockNode
@@ -55,9 +55,9 @@ class SelectionConstraintGenerator(
     private val costEstimator: CostEstimator<IntegerCost>,
 ) {
     private val nameGenerator = FreshNameGenerator()
-    private val hostTrustConfiguration = HostTrustConfiguration.get(program)
-    private val nameAnalysis = NameAnalysis.get(program)
-    private val informationFlowAnalysis = InformationFlowAnalysis.get(program)
+    private val hostTrustConfiguration = program.analyses.get<HostTrustConfiguration>()
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
+    private val informationFlowAnalysis = program.analyses.get<InformationFlowAnalysis>()
 
     private val costChoiceMap =
         mutableMapOf<CostVariable, MutableList<Pair<SelectionConstraint, Cost<IntegerCost>>>>()

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/selection/ValidateSelection.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/selection/ValidateSelection.kt
@@ -1,8 +1,8 @@
 package io.github.aplcornell.viaduct.selection
 
+import io.github.aplcornell.viaduct.analysis.HostTrustConfiguration
 import io.github.aplcornell.viaduct.analysis.InformationFlowAnalysis
 import io.github.aplcornell.viaduct.analysis.NameAnalysis
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 import io.github.aplcornell.viaduct.syntax.Protocol
 import io.github.aplcornell.viaduct.syntax.intermediate.Node
 import io.github.aplcornell.viaduct.syntax.intermediate.ProgramNode
@@ -24,9 +24,9 @@ fun validateProtocolAssignment(
     val constraintGenerator =
         SelectionConstraintGenerator(program, protocolFactory, protocolComposer, costEstimator)
 
-    val nameAnalysis = NameAnalysis.get(program)
-    val informationFlowAnalysis = InformationFlowAnalysis.get(program)
-    val hostTrustConfiguration = HostTrustConfiguration.get(program)
+    val hostTrustConfiguration = program.analyses.get<HostTrustConfiguration>()
+    val nameAnalysis = program.analyses.get<NameAnalysis>()
+    val informationFlowAnalysis = program.analyses.get<InformationFlowAnalysis>()
 
     fun checkViableProtocol(selection: ProtocolAssignment, node: VariableDeclarationNode) {
         val functionName = nameAnalysis.enclosingFunctionName(node as Node)

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/intermediate/ProgramNode.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/intermediate/ProgramNode.kt
@@ -36,10 +36,7 @@ private constructor(
     val functionMap: Map<FunctionName, FunctionDeclarationNode>
         get() = functions.associateBy { function -> function.name.value }
 
-    private val internal_analyses = AnalysisProvider(this)
-
-    val analyses: AnalysisProvider<Node, ProgramNode>
-        get() = internal_analyses
+    val analyses: AnalysisProvider<Node, ProgramNode> = AnalysisProvider(this)
 
     override val children: Iterable<TopLevelDeclarationNode>
         get() = declarations

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/intermediate/ProgramNode.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/intermediate/ProgramNode.kt
@@ -1,8 +1,6 @@
 package io.github.aplcornell.viaduct.syntax.intermediate
 
-import io.github.aplcornell.viaduct.attributes.Attribute
-import io.github.aplcornell.viaduct.attributes.Tree
-import io.github.aplcornell.viaduct.attributes.attribute
+import io.github.aplcornell.viaduct.analysis.AnalysisProvider
 import io.github.aplcornell.viaduct.passes.elaborated
 import io.github.aplcornell.viaduct.syntax.FunctionName
 import io.github.aplcornell.viaduct.syntax.Host
@@ -38,20 +36,10 @@ private constructor(
     val functionMap: Map<FunctionName, FunctionDeclarationNode>
         get() = functions.associateBy { function -> function.name.value }
 
-    /** A lazily constructed [Tree] instance for the program. */
-    val tree: Tree<Node, ProgramNode> by lazy { Tree(this) }
+    private val internal_analyses = AnalysisProvider(this)
 
-    private val functionCache: Attribute<(ProgramNode) -> Any?, Any?> = attribute {
-        this.invoke(this@ProgramNode)
-    }
-
-    /**
-     * Applies [function] to this program and returns the results.
-     * The result is cached, so future calls with the same function do not evaluate [function].
-     */
-    @Suppress("UNCHECKED_CAST")
-    fun <T> cached(function: (ProgramNode) -> T): T =
-        functionCache(function) as T
+    val analyses: AnalysisProvider<Node, ProgramNode>
+        get() = internal_analyses
 
     override val children: Iterable<TopLevelDeclarationNode>
         get() = declarations

--- a/compiler/src/test/kotlin/io/github/aplcornell/viaduct/analysis/InformationFlowAnalysisTest.kt
+++ b/compiler/src/test/kotlin/io/github/aplcornell/viaduct/analysis/InformationFlowAnalysisTest.kt
@@ -12,14 +12,14 @@ internal class InformationFlowAnalysisTest {
     @ParameterizedTest
     @ArgumentsSource(PositiveTestProgramProvider::class)
     fun `it information flow checks`(program: ProgramNode) {
-        InformationFlowAnalysis.get(program.elaborated()).check()
+        program.elaborated().analyses.get<InformationFlowAnalysis>().check()
     }
 
     @ParameterizedTest
     @ArgumentsSource(PositiveTestProgramProvider::class)
     fun `it has a valid constraint graph representation`(program: ProgramNode) {
         val elaboratedProgram = program.elaborated()
-        val informationFlowAnalysis = InformationFlowAnalysis.get(elaboratedProgram)
+        val informationFlowAnalysis = elaboratedProgram.analyses.get<InformationFlowAnalysis>()
         elaboratedProgram.check()
         val writer = StringWriter()
         informationFlowAnalysis.exportConstraintGraph(writer)

--- a/compiler/src/test/kotlin/io/github/aplcornell/viaduct/analysis/NameAnalysisTest.kt
+++ b/compiler/src/test/kotlin/io/github/aplcornell/viaduct/analysis/NameAnalysisTest.kt
@@ -11,14 +11,14 @@ internal class NameAnalysisTest {
     @ParameterizedTest
     @ArgumentsSource(PositiveTestProgramProvider::class)
     fun `it name checks`(program: ProgramNode) {
-        NameAnalysis.get(program.elaborated()).check()
+        program.elaborated().analyses.get<NameAnalysis>().check()
     }
 
     @ParameterizedTest
     @ArgumentsSource(PositiveTestProgramProvider::class)
     fun `temporary definitions are mapped to reads`(surfaceProgram: ProgramNode) {
         val program = surfaceProgram.elaborated()
-        val nameAnalysis = NameAnalysis.get(program)
+        val nameAnalysis = program.analyses.get<NameAnalysis>()
         program.descendantsIsInstance<LetNode>().forEach { declaration -> nameAnalysis.readers(declaration) }
     }
 }

--- a/compiler/src/test/kotlin/io/github/aplcornell/viaduct/analysis/TypeAnalysisTest.kt
+++ b/compiler/src/test/kotlin/io/github/aplcornell/viaduct/analysis/TypeAnalysisTest.kt
@@ -10,6 +10,6 @@ internal class TypeAnalysisTest {
     @ParameterizedTest
     @ArgumentsSource(PositiveTestProgramProvider::class)
     fun `it type checks`(program: ProgramNode) {
-        TypeAnalysis.get(program.elaborated()).check()
+        program.elaborated().analyses.get<TypeAnalysis>().check()
     }
 }

--- a/compiler/src/test/kotlin/io/github/aplcornell/viaduct/passes/RewriteTest.kt
+++ b/compiler/src/test/kotlin/io/github/aplcornell/viaduct/passes/RewriteTest.kt
@@ -1,6 +1,7 @@
 package io.github.aplcornell.viaduct.passes
 
 import io.github.aplcornell.viaduct.algebra.FreeDistributiveLattice
+import io.github.aplcornell.viaduct.analysis.HostTrustConfiguration
 import io.github.aplcornell.viaduct.parsing.parse
 import io.github.aplcornell.viaduct.security.ConfidentialityComponent
 import io.github.aplcornell.viaduct.security.HostPrincipal
@@ -16,7 +17,6 @@ import io.github.aplcornell.viaduct.security.LabelTop
 import io.github.aplcornell.viaduct.security.PolymorphicPrincipal
 import io.github.aplcornell.viaduct.security.Principal
 import io.github.aplcornell.viaduct.syntax.Host
-import io.github.aplcornell.viaduct.syntax.HostTrustConfiguration
 import io.github.aplcornell.viaduct.syntax.LabelVariable
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -41,7 +41,7 @@ internal class RewriteTest {
     private fun pl(s: String) = LabelParameter(p(s))
 
     private val emptyTrustConfiguration =
-        HostTrustConfiguration.get("fun main() {}".parse().elaborated())
+        "fun main() {}".parse().elaborated().analyses.get<HostTrustConfiguration>()
 
     private val top = FreeDistributiveLattice.bounds<PrincipalComponent>().top
     private val bottom = FreeDistributiveLattice.bounds<PrincipalComponent>().bottom

--- a/compiler/src/test/kotlin/io/github/aplcornell/viaduct/syntax/StructuralEquality.kt
+++ b/compiler/src/test/kotlin/io/github/aplcornell/viaduct/syntax/StructuralEquality.kt
@@ -1,5 +1,6 @@
 package io.github.aplcornell.viaduct.syntax
 
+import io.github.aplcornell.viaduct.analysis.AnalysisProvider
 import io.github.aplcornell.viaduct.prettyprinting.PrettyPrintable
 import org.junit.jupiter.api.assertThrows
 import org.opentest4j.AssertionFailedError
@@ -23,6 +24,9 @@ internal fun assertStructurallyNotEquals(expected: HasSourceLocation, actual: Ha
 private fun assertEquals(expected: Any?, actual: Any?) {
     when {
         expected is SourceLocation && actual is SourceLocation ->
+            return
+
+        expected is AnalysisProvider<*, *> && actual is AnalysisProvider<*, *> ->
             return
 
         expected is List<*> && actual is List<*> -> {

--- a/interpreter/src/main/kotlin/io/github/aplcornell/viaduct/backend/BackendInterpreter.kt
+++ b/interpreter/src/main/kotlin/io/github/aplcornell/viaduct/backend/BackendInterpreter.kt
@@ -40,7 +40,7 @@ class BackendInterpreter(
     private val protocolInterpreters: List<ProtocolInterpreter>,
     private val runtime: ViaductProcessRuntime,
 ) {
-    private val nameAnalysis = NameAnalysis.get(program)
+    private val nameAnalysis = program.analyses.get<NameAnalysis>()
     private val protocolInterpreterMap: Map<Protocol, ProtocolInterpreter>
     private val syncProtocol = Synchronization(program.hostDeclarations.map { it.name.value }.toSet())
 
@@ -51,7 +51,11 @@ class BackendInterpreter(
             val interpreterProtocols = interpreter.availableProtocols
             for (protocol in interpreterProtocols) {
                 if (currentProtocols.contains(protocol)) {
-                    throw ViaductInterpreterError("Interpreter: Multiple backends for protocol ${protocol.toDocument().print()}")
+                    throw ViaductInterpreterError(
+                        "Interpreter: Multiple backends for protocol ${
+                            protocol.toDocument().print()
+                        }",
+                    )
                 } else {
                     currentProtocols.add(protocol)
                     initInterpreterMap[protocol] = interpreter
@@ -201,7 +205,11 @@ class BackendInterpreter(
                             is ReadNode -> {
                                 val guardProtocol = protocolAnalysis.primaryProtocol(guard)
                                 protocolInterpreterMap[guardProtocol]?.runGuard(guardProtocol, guard)
-                                    ?: throw ViaductInterpreterError("no backend for protocol ${guardProtocol.toDocument().print()}")
+                                    ?: throw ViaductInterpreterError(
+                                        "no backend for protocol ${
+                                            guardProtocol.toDocument().print()
+                                        }",
+                                    )
                             }
                         }
 

--- a/interpreter/src/main/kotlin/io/github/aplcornell/viaduct/backend/aby/ABYProtocolInterpreter.kt
+++ b/interpreter/src/main/kotlin/io/github/aplcornell/viaduct/backend/aby/ABYProtocolInterpreter.kt
@@ -85,7 +85,7 @@ class ABYProtocolInterpreter(
             setOf(ArithABY(otherHost, host), BoolABY(otherHost, host), YaoABY(otherHost, host))
         }
 
-    private val typeAnalysis = TypeAnalysis.get(program)
+    private val typeAnalysis = program.analyses.get<TypeAnalysis>()
     private val aby: ABYParty
 
     private val ssTempStoreStack: Stack<PersistentMap<Temporary, ABYCircuitGate>> = Stack()


### PR DESCRIPTION
We cache `Analysis` instances for each `ProgramNode` for efficiency. For example, multiple places in the compiler use information flow labels which are provided by `InformationFlowAnalysis`, but we don't want to perform `InformationFlowAnalysis` on the same program multiple times. Before, each `Analysis` instance had to copy paste boilerplate code for caching. This PR uses reflection instead.

One big downside is that the `compiler` module now depends on the `kotlin-reflection` module.