### PR TITLE
Throw an error when protocol annotations have bad arguments

### DIFF
--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/aby/ABYProtocolParser.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/aby/ABYProtocolParser.kt
@@ -9,6 +9,7 @@ object ArithABYProtocolParser : ProtocolParser<ArithABY> {
     override fun parse(arguments: ProtocolArguments): ArithABY {
         val server = arguments.get<HostValue>("server")
         val client = arguments.get<HostValue>("client")
+        checkArguments(arguments)
         return ArithABY(server.value, client.value)
     }
 }
@@ -17,6 +18,7 @@ object BoolABYProtocolParser : ProtocolParser<BoolABY> {
     override fun parse(arguments: ProtocolArguments): BoolABY {
         val server = arguments.get<HostValue>("server")
         val client = arguments.get<HostValue>("client")
+        checkArguments(arguments)
         return BoolABY(server.value, client.value)
     }
 }
@@ -25,6 +27,16 @@ object YaoABYProtocolParser : ProtocolParser<YaoABY> {
     override fun parse(arguments: ProtocolArguments): YaoABY {
         val server = arguments.get<HostValue>("server")
         val client = arguments.get<HostValue>("client")
+        checkArguments(arguments)
         return YaoABY(server.value, client.value)
+    }
+}
+
+private fun checkArguments(arguments: ProtocolArguments) {
+    val server = arguments.get<HostValue>("server")
+    arguments.getAndAlso<HostValue>("client") {
+        if (server == it) {
+            throw IllegalArgumentException("client must be different from server")
+        }
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/cleartext/ReplicationProtocolParser.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/cleartext/ReplicationProtocolParser.kt
@@ -7,7 +7,11 @@ import io.github.aplcornell.viaduct.syntax.values.HostSetValue
 /** Parser for the [Replication] protocol. */
 object ReplicationProtocolParser : ProtocolParser<Replication> {
     override fun parse(arguments: ProtocolArguments): Replication {
-        val hosts = arguments.get<HostSetValue>("hosts")
+        val hosts = arguments.getAndAlso<HostSetValue>("hosts") {
+            if (it.size < 2) {
+                throw IllegalArgumentException("need at least 2 hosts")
+            }
+        }
         return Replication(hosts)
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentProtocolParser.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/commitment/CommitmentProtocolParser.kt
@@ -9,7 +9,14 @@ import io.github.aplcornell.viaduct.syntax.values.HostValue
 object CommitmentProtocolParser : ProtocolParser<Commitment> {
     override fun parse(arguments: ProtocolArguments): Commitment {
         val sender = arguments.get<HostValue>("sender")
-        val receivers = arguments.get<HostSetValue>("receivers")
+        val receivers = arguments.getAndAlso<HostSetValue>("receivers") {
+            if (it.isEmpty()) {
+                throw IllegalArgumentException("receivers cannot be empty")
+            }
+            if (sender.value in it) {
+                throw IllegalArgumentException("receivers cannot contain sender")
+            }
+        }
         return Commitment(sender.value, receivers)
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/zkp/ZKPProtocolParser.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/backends/zkp/ZKPProtocolParser.kt
@@ -9,7 +9,14 @@ import io.github.aplcornell.viaduct.syntax.values.HostValue
 object ZKPProtocolParser : ProtocolParser<ZKP> {
     override fun parse(arguments: ProtocolArguments): ZKP {
         val sender = arguments.get<HostValue>("prover")
-        val receivers = arguments.get<HostSetValue>("verifiers")
+        val receivers = arguments.getAndAlso<HostSetValue>("verifiers") {
+            if (it.isEmpty()) {
+                throw IllegalArgumentException("verifiers cannot be empty")
+            }
+            if (sender.value in it) {
+                throw IllegalArgumentException("verifiers cannot contain prover")
+            }
+        }
         return ZKP(sender.value, receivers)
     }
 }

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/errors/MalformedProtocolAnnotationError.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/errors/MalformedProtocolAnnotationError.kt
@@ -1,0 +1,21 @@
+package io.github.aplcornell.viaduct.errors
+
+import io.github.aplcornell.viaduct.prettyprinting.Document
+import io.github.aplcornell.viaduct.syntax.HasSourceLocation
+
+/** Thrown when a protocol is applied to bad arguments. */
+class MalformedProtocolAnnotationError(
+    private val annotation: HasSourceLocation,
+    private val reason: String,
+) : CompilationError() {
+    override val category: String
+        get() = "Malformed Protocol Annotation"
+
+    override val source: String
+        get() = annotation.sourceLocation.sourcePath
+
+    override val description: Document
+        get() =
+            Document("${reason.replaceFirstChar { it.uppercaseChar() }}:")
+                .withSource(annotation.sourceLocation)
+}

--- a/compiler/tests/should-fail/InvalidProtocolAnnotation.via
+++ b/compiler/tests/should-fail/InvalidProtocolAnnotation.via
@@ -1,8 +1,8 @@
 /* InvalidProtocolAnnotationError */
 
 host alice
-host b
+host bob
 
 fun main() {
-    val a: int{b}@Local(host = alice) = 42;
+    val a: int{bob}@Local(host = alice) = 42;
 }

--- a/compiler/tests/should-fail/MalformedProtocolAnnotation.via
+++ b/compiler/tests/should-fail/MalformedProtocolAnnotation.via
@@ -1,0 +1,7 @@
+/* MalformedProtocolAnnotationError */
+
+host alice
+
+fun main() {
+    val x:int@Replication(hosts = {alice}) = 5;
+}

--- a/compiler/tests/should-fail/MalformedProtocolAnnotation2.via
+++ b/compiler/tests/should-fail/MalformedProtocolAnnotation2.via
@@ -1,0 +1,7 @@
+/* MalformedProtocolAnnotationError */
+
+host alice
+
+fun main() {
+    val x:int@Commitment(sender = alice, receivers = {}) = 5;
+}

--- a/compiler/tests/should-fail/MalformedProtocolAnnotation3.via
+++ b/compiler/tests/should-fail/MalformedProtocolAnnotation3.via
@@ -1,0 +1,7 @@
+/* MalformedProtocolAnnotationError */
+
+host alice
+
+fun main() {
+    val x:int@Commitment(sender = alice, receivers = {alice}) = 5;
+}

--- a/compiler/tests/should-fail/MalformedProtocolAnnotation4.via
+++ b/compiler/tests/should-fail/MalformedProtocolAnnotation4.via
@@ -1,0 +1,7 @@
+/* MalformedProtocolAnnotationError */
+
+host alice
+
+fun main() {
+    val x:int@ZKP(prover = alice, verifiers = {}) = 5;
+}

--- a/compiler/tests/should-fail/MalformedProtocolAnnotation5.via
+++ b/compiler/tests/should-fail/MalformedProtocolAnnotation5.via
@@ -1,0 +1,7 @@
+/* MalformedProtocolAnnotationError */
+
+host alice
+
+fun main() {
+    val x:int@ZKP(prover = alice, verifiers = {alice}) = 5;
+}

--- a/compiler/tests/should-fail/MalformedProtocolAnnotation6.via
+++ b/compiler/tests/should-fail/MalformedProtocolAnnotation6.via
@@ -1,0 +1,7 @@
+/* MalformedProtocolAnnotationError */
+
+host alice
+
+fun main() {
+    val x:int@BoolABY(server = alice, client = alice) = 5;
+}


### PR DESCRIPTION
Protocol annotations with malformed arguments cause an internal compiler error. This PR fixes that by generating proper error messages for the user. For instance, the program

```kotlin
fun main() {
    val x:int@Replication(hosts = {alice}) = 5;
}
```

now generates

```shell
-- MALFORMED PROTOCOL ANNOTATION - compiler/tests/should-fail/MalformedProtocolAnnotation.via

Need at least 2 hosts:

6|     val x:int@Replication(hosts = {alice}) = 5;
                                     ^^^^^^^
```