### PR TITLE
[AIRduct] remove unecessary returns in circuit parsing

### DIFF
--- a/compiler/src/main/cup/io/github/aplcornell/viaduct/syntax/circuit/CircuitParser.cup
+++ b/compiler/src/main/cup/io/github/aplcornell/viaduct/syntax/circuit/CircuitParser.cup
@@ -87,11 +87,12 @@ nonterminal List<TopLevelDeclarationNode> declaration_list;
 nonterminal TopLevelDeclarationNode declaration;
 
 nonterminal ReturnNode return;
-nonterminal BlockNode<StatementNode> block;
+nonterminal RoutineBlockNode<StatementNode> func_block;
+nonterminal ControlFlowBlockNode<StatementNode> flow_block;
 nonterminal List<StatementNode> stmt_list;
 nonterminal StatementNode stmt;
 nonterminal CommandNode command;
-nonterminal BlockNode<CircuitStatementNode> circ_block;
+nonterminal RoutineBlockNode<CircuitStatementNode> circ_block;
 nonterminal List<CircuitStatementNode> circ_stmt_list;
 nonterminal CircuitStatementNode circ_stmt;
 
@@ -220,7 +221,7 @@ declaration ::=
         );
     :}
   | FUNCTION:begin LT:sizesopen size_list:sizes GT:sizesclose IDENT:funcname
-        OPEN_PAREN:paramsbegin parameter_list:inparams CLOSE_PAREN:paramsclose RARROW:arrow parameter_list:outparams block:body {:
+        OPEN_PAREN:paramsbegin parameter_list:inparams CLOSE_PAREN:paramsclose RARROW:arrow parameter_list:outparams func_block:body {:
           RESULT = new FunctionDeclarationNode(
             new Located(new FunctionName(funcname), location(funcnameleft, funcnameright)),
             new Arguments(sizes, location(sizesopenleft, sizescloseright)),
@@ -322,9 +323,15 @@ var_binding ::=
     :}
   ;
 
-block ::=
+func_block ::=
     OPEN_BRACE:begin stmt_list:statements return:ret CLOSE_BRACE:end {:
-      RESULT = new BlockNode(statements, ret, location(beginleft, endright));
+      RESULT = new RoutineBlockNode(statements, ret, location(beginleft, endright));
+    :}
+  ;
+
+flow_block ::=
+    OPEN_BRACE:begin stmt_list:statements CLOSE_BRACE:end {:
+      RESULT = new ControlFlowBlockNode(statements, location(beginleft, endright));
     :}
   ;
 
@@ -364,10 +371,10 @@ command ::=
   | host:recipient PERIOD OUTPUT LT array_type:type GT OPEN_PAREN reference:message CLOSE_PAREN:end {:
       RESULT = new OutputNode(type, message, recipient, location(recipientleft, endright));
   :}
-  | IF:begin OPEN_PAREN index_expr:guard CLOSE_PAREN block:thenbranch ELSE block:elsebranch {:
+  | IF:begin OPEN_PAREN index_expr:guard CLOSE_PAREN flow_block:thenbranch ELSE flow_block:elsebranch {:
       RESULT = new IfNode(guard, thenbranch, elsebranch, location(beginleft, elsebranchright));
   :}
-  | LOOP:begin block:body {:
+  | LOOP:begin flow_block:body {:
       RESULT = new LoopNode(body, location(beginleft, bodyright));
   :}
   | BREAK:b {: RESULT = new BreakNode(location(bleft,bright)); :}
@@ -375,7 +382,7 @@ command ::=
 
 circ_block ::=
     OPEN_BRACE:begin circ_stmt_list:statements return:ret CLOSE_BRACE:end {:
-      RESULT = new BlockNode(statements, ret, location(beginleft, endright));
+      RESULT = new RoutineBlockNode(statements, ret, location(beginleft, endright));
     :}
   ;
 

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/circuit/Statements.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/circuit/Statements.kt
@@ -25,13 +25,38 @@ sealed class CircuitStatementNode : StatementNode()
 
 sealed class CommandNode : Node()
 
-/** A sequence of statements. */
-class BlockNode<Statement : StatementNode>
-private constructor(
-    val statements: PersistentList<Statement>,
-    val returnStatement: ReturnNode,
+/** Any sequence of statements */
+abstract class BlockNode<Statement : StatementNode>(
+    open val statements: List<Statement>,
     override val sourceLocation: SourceLocation,
-) : Node(), List<Statement> by statements {
+) : Node(), List<Statement>
+
+/** A sequence of statements not followed by a return. */
+class ControlFlowBlockNode<Statement : StatementNode>
+private constructor(
+    statements: PersistentList<Statement>,
+    sourceLocation: SourceLocation,
+) : BlockNode<Statement>(statements = statements, sourceLocation = sourceLocation), List<Statement> by statements {
+    constructor(statements: List<Statement>, sourceLocation: SourceLocation) :
+        this(statements.toPersistentList(), sourceLocation)
+
+    override val children: Iterable<Node>
+        get() = statements
+
+    override fun toDocument(): Document {
+        val statements: MutableList<Document> = (statements.map { it.toDocument() } as MutableList<Document>)
+        val body: Document = statements.concatenated(separator = Document.forcedLineBreak)
+        return listOf((Document.forcedLineBreak + body).nested() + Document.forcedLineBreak).braced()
+    }
+}
+
+/** A sequence of statements followed by a return. */
+class RoutineBlockNode<Statement : StatementNode>
+private constructor(
+    statements: PersistentList<Statement>,
+    val returnStatement: ReturnNode,
+    sourceLocation: SourceLocation,
+) : BlockNode<Statement>(statements = statements, sourceLocation = sourceLocation), List<Statement> by statements {
     constructor(statements: List<Statement>, returnStatement: ReturnNode, sourceLocation: SourceLocation) :
         this(statements.toPersistentList(), returnStatement, sourceLocation)
 
@@ -157,7 +182,7 @@ class IfNode(
     val guard: IndexExpressionNode,
     val thenBranch: BlockNode<StatementNode>,
     val elseBranch: BlockNode<StatementNode>,
-    override val sourceLocation: SourceLocation
+    override val sourceLocation: SourceLocation,
 ) : ControlNode() {
     override val children: Iterable<Node>
         get() = listOf(guard, thenBranch, elseBranch)

--- a/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/circuit/TopLevelDeclarations.kt
+++ b/compiler/src/main/kotlin/io/github/aplcornell/viaduct/syntax/circuit/TopLevelDeclarations.kt
@@ -62,7 +62,7 @@ class CircuitDeclarationNode(
     val sizes: Arguments<SizeParameterNode>,
     val inputs: Arguments<ParameterNode>,
     val outputs: Arguments<ParameterNode>,
-    val body: BlockNode<CircuitStatementNode>,
+    val body: RoutineBlockNode<CircuitStatementNode>,
     override val sourceLocation: SourceLocation,
 ) : TopLevelDeclarationNode() {
     override val children: Iterable<Node>
@@ -77,7 +77,7 @@ class FunctionDeclarationNode(
     val sizes: Arguments<SizeParameterNode>,
     val inputs: Arguments<ParameterNode>,
     val outputs: Arguments<ParameterNode>,
-    val body: BlockNode<StatementNode>,
+    val body: RoutineBlockNode<StatementNode>,
     override val sourceLocation: SourceLocation,
 ) : TopLevelDeclarationNode() {
     override val children: Iterable<Node>

--- a/compiler/tests/should-pass/circuit/ctrlflow.circuit
+++ b/compiler/tests/should-pass/circuit/ctrlflow.circuit
@@ -6,27 +6,21 @@ fun <> main() -> {
     val z@Local(host = alice) = alice.input<int[]>()
     val = if (true) {
       val = alice.output<int[]>(x)
-      return
     }
-    else { return }
+    else { }
     val = if (false) {
       val = alice.output<int[]>(y)
-      return
     }
     else {
       val = loop {
           val stop@Local(host = alice) = alice.input<bool[]>()
           val = if (stop) {
             val = break
-            return
           }
           else {
             val = alice.output<int[]>(z)
-            return
           }
-          return
       }
-      return
     }
     return
 }


### PR DESCRIPTION
This PR modifies the Circuit parsing:

- Separate the Block for Circuits & Functions (`RoutineBlockNode`) and for Control Flow (`ControlFlowBlockNode`)
- `ControlFlowBlockNode`s do not have a return at the end
- Modify `CircuitParser.cup` to allow for the new flow blocks